### PR TITLE
Add GPU support via `cupy` with fuse kernels

### DIFF
--- a/format_code.sh
+++ b/format_code.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-black pyffs/* -l 100
-black test/* -l 100
-black profile/* -l 100
+black pyffs/*.py -l 100
+black test/*.py -l 100
+black profile/*.py -l 100
 black test.py -l 100

--- a/profile/ffsn.py
+++ b/profile/ffsn.py
@@ -4,10 +4,9 @@ import time
 import click
 import matplotlib.pyplot as plt
 import numpy as np
-from scipy.fftpack import next_fast_len
 
 import util
-from pyffs import ffsn_sample, ffsn, _ffsn
+from pyffs import ffsn_sample, ffsn, _ffsn, next_fast_len
 from pyffs.func import dirichlet_2D
 
 

--- a/profile/ffsn.py
+++ b/profile/ffsn.py
@@ -8,16 +8,17 @@ import numpy as np
 import util
 from pyffs import ffsn_sample, ffsn, _ffsn, next_fast_len
 from pyffs.func import dirichlet_2D
+from pyffs.backend import AVAILABLE_MOD, get_module_name
 
 
 @click.command()
-@click.option("--n_trials", type=int, default=5)
+@click.option("--n_trials", type=int, default=10)
 def profile_ffsn(n_trials):
     print(f"\nCOMPARING FFSN APPROACHES WITH {n_trials} TRIALS")
 
     T = [1, 1]
     T_c = [0, 0]
-    N_FS_vals = [101, 301, 1001, 3001, 10001]
+    N_FS_vals = [11, 31, 101, 301, 1001, 3001, 10001]
 
     n_std = 1
 
@@ -25,32 +26,39 @@ def profile_ffsn(n_trials):
 
     proc_time = dict()
     proc_time_std = dict()
+
     for _N_FS in N_FS_vals:
-
-        N_FS = [_N_FS, _N_FS]
-        _N_s = next_fast_len(_N_FS)
-        N_s = [_N_s, _N_s]
-
         print("\nN_FS : {}".format(_N_FS))
-        print("N_s : {}".format(_N_s))
+        N_FS = [_N_FS, _N_FS]
         proc_time[_N_FS] = dict()
         proc_time_std[_N_FS] = dict()
 
-        # Sample the kernel and do the transform.
-        sample_points, _ = ffsn_sample(T=T, N_FS=N_FS, T_c=T_c, N_s=N_s)
-        diric_samples = dirichlet_2D(sample_points=sample_points, T=T, T_c=T_c, N_FS=N_FS)
+        # Loop through modules
+        for mod in AVAILABLE_MOD:
 
-        # Loop through functions
-        for _f in func:
-            timings = []
-            for _ in range(n_trials):
-                start_time = time.time()
-                func[_f](x=diric_samples, T=T, N_FS=N_FS, T_c=T_c)
-                timings.append(time.time() - start_time)
-            proc_time[_N_FS][_f] = np.mean(timings)
-            proc_time_std[_N_FS][_f] = np.std(timings)
+            backend = get_module_name(mod)
 
-            print("{} : {} seconds".format(_f, proc_time[_N_FS][_f]))
+            # fastest FFT length depends on module
+            _N_s = next_fast_len(_N_FS, mod=mod)
+            N_s = [_N_s, _N_s]
+            print("-- module : {}, Length-{} FFT".format(backend, N_s))
+
+            for _f in func:
+
+                # Sample the kernel and do the transform.
+                sample_points, _ = ffsn_sample(T=T, N_FS=N_FS, T_c=T_c, N_s=N_s, mod=mod)
+                diric_samples = dirichlet_2D(sample_points=sample_points, T=T, T_c=T_c, N_FS=N_FS)
+
+                _key = "{}_{}".format(_f, backend)
+                timings = []
+                for _ in range(n_trials):
+                    start_time = time.time()
+                    func[_f](x=diric_samples, T=T, N_FS=N_FS, T_c=T_c)
+                    timings.append(time.time() - start_time)
+                proc_time[_N_FS][_key] = np.mean(timings)
+                proc_time_std[_N_FS][_key] = np.std(timings)
+
+                print("{} : {} seconds".format(_f, proc_time[_N_FS][_key]))
 
     # plot results
     fig, ax = plt.subplots()
@@ -58,7 +66,7 @@ def profile_ffsn(n_trials):
     ax.set_xlabel("Number of FS coefficients")
     fig.tight_layout()
 
-    fname = pathlib.Path(__file__).resolve().parent / "ffsn_comparison.png"
+    fname = pathlib.Path(__file__).resolve().parent / "profile_ffsn_2d.png"
     fig.savefig(fname, dpi=300)
 
 

--- a/profile/fs_interp.py
+++ b/profile/fs_interp.py
@@ -33,7 +33,7 @@ def profile_fs_interp(n_trials):
 
     # parameters of signal
     T, T_c, M = math.pi, math.e, 1000
-    N_FS_vals = [11, 31, 101, 301, 1001, 3001, 10001]
+    N_FS_vals = [11, 31, 101, 301, 1001, 3001, 10001, 30001, 100001]
 
     # sweep over number of interpolation points
     a, b = T_c + (T / 2) * np.r_[-1, 1]

--- a/profile/fs_interp.py
+++ b/profile/fs_interp.py
@@ -9,21 +9,36 @@ import numpy as np
 import util
 from pyffs.func import dirichlet_fs
 from pyffs.interp import fs_interp
+from pyffs.backend import AVAILABLE_MOD, get_module_name
+
+
+def naive_interp1d(diric_FS, T, a, b, M):
+
+    sample_points = np.linspace(start=a, stop=b, num=M, endpoint=False)
+
+    # loop as could be large matrix
+    N_FS = len(diric_FS)
+    K = N_FS // 2
+    fs_idx = np.arange(-K, K + 1)
+    vals = np.zeros(len(sample_points), dtype=complex)
+    for i, _x_val in enumerate(sample_points):
+        vals[i] = np.dot(diric_FS, np.exp(1j * 2 * np.pi / T * _x_val * fs_idx))
+    return vals
 
 
 @click.command()
-@click.option("--n_trials", type=int, default=50)
+@click.option("--n_trials", type=int, default=10)
 def profile_fs_interp(n_trials):
     print(f"\nCOMPARING FS_INTERP WITH {n_trials} TRIALS")
 
     # parameters of signal
     T, T_c, M = math.pi, math.e, 1000
+    N_FS_vals = [11, 31, 101, 301, 1001, 3001, 10001]
 
     # sweep over number of interpolation points
     a, b = T_c + (T / 2) * np.r_[-1, 1]
-    n_std = 1.0
+    n_std = 0.5
     real_x = {"complex": False, "real": True}
-    N_FS_vals = [1001, 3001, 10001, 30001, 100001, 30001, 100001]
     proc_time = dict()
     proc_time_std = dict()
     for N_FS in N_FS_vals:
@@ -31,19 +46,37 @@ def profile_fs_interp(n_trials):
         proc_time[N_FS] = dict()
         proc_time_std[N_FS] = dict()
 
-        # compute FS coefficients
-        diric_FS = dirichlet_fs(N_FS, T, T_c)
+        # naive approach, apply synthesis formula
+        diric_FS = dirichlet_fs(N_FS, T, T_c, mod=np)
+        _key = "naive"
+        timings = []
+        for _ in range(n_trials):
+            start_time = time.time()
+            naive_interp1d(diric_FS, T, a, b, M)
+            timings.append(time.time() - start_time)
+        proc_time[N_FS][_key] = np.mean(timings)
+        proc_time_std[N_FS][_key] = np.std(timings)
+        print("-- {} : {} seconds".format(_key, proc_time[N_FS][_key]))
 
-        # Loop through functions
-        for _f in real_x:
-            timings = []
-            for _ in range(n_trials):
-                start_time = time.time()
-                fs_interp(diric_FS, T, a, b, M, real_x=real_x[_f])
-                timings.append(time.time() - start_time)
-            proc_time[N_FS][_f] = np.mean(timings)
-            proc_time_std[N_FS][_f] = np.std(timings)
-            print("{} version : {} seconds".format(_f, proc_time[N_FS][_f]))
+        # Loop through modules
+        for mod in AVAILABLE_MOD:
+            backend = get_module_name(mod)
+            print("-- module : {}".format(backend))
+
+            # compute FS coefficients
+            diric_FS = dirichlet_fs(N_FS, T, T_c, mod=mod)
+
+            # Loop through functions
+            for _f in real_x:
+                _key = "{}_{}".format(_f, backend)
+                timings = []
+                for _ in range(n_trials):
+                    start_time = time.time()
+                    fs_interp(diric_FS, T, a, b, M, real_x=real_x[_f])
+                    timings.append(time.time() - start_time)
+                proc_time[N_FS][_key] = np.mean(timings)
+                proc_time_std[N_FS][_key] = np.std(timings)
+                print("{} version : {} seconds".format(_f, proc_time[N_FS][_key]))
 
     # plot results
     fig, ax = plt.subplots()
@@ -52,7 +85,7 @@ def profile_fs_interp(n_trials):
     ax.set_xlabel("Number of FS coefficients")
     fig.tight_layout()
 
-    fname = pathlib.Path(__file__).resolve().parent / "fs_interp_1D_real_speedup.png"
+    fname = pathlib.Path(__file__).resolve().parent / "profile_fs_interp_1D.png"
     fig.savefig(fname, dpi=300)
 
 

--- a/profile/fs_interp2.py
+++ b/profile/fs_interp2.py
@@ -9,41 +9,51 @@ import numpy as np
 import util
 from pyffs.func import dirichlet_fs
 from pyffs.interp import fs_interpn
+from pyffs.backend import AVAILABLE_MOD, get_module_name
 
 
 @click.command()
-@click.option("--n_trials", type=int, default=50)
+@click.option("--n_trials", type=int, default=10)
 def profile_fs_interp2(n_trials):
     print(f"\nCOMPARING FS_INTERP WITH {n_trials} TRIALS")
 
     # parameters of signal
     T, T_c, M = math.pi, math.e, 10  # M^2 number of samples
+    N_FS_vals = [11, 31, 101, 301, 1001, 3001, 10001]  # N_FS^2 coefficients
 
     # sweep over number of interpolation points
     a, b = T_c + (T / 2) * np.r_[-1, 1]
-    n_std = 1.0
+    n_std = 0.5
     real_x = {"complex": False, "real": True}
-    N_FS_vals = [11, 31, 101, 301, 1001, 3001]  # N_FS^2 coefficients
     proc_time = dict()
     proc_time_std = dict()
+
     for N_FS in N_FS_vals:
         print("\nNumber of FS coefficients : {}".format(N_FS))
         proc_time[N_FS] = dict()
         proc_time_std[N_FS] = dict()
 
-        # compute FS coefficients
-        diric_FS = np.outer(dirichlet_fs(N_FS, T, T_c), dirichlet_fs(N_FS, T, T_c))
+        # Loop through modules
+        for mod in AVAILABLE_MOD:
+            backend = get_module_name(mod)
+            print("-- module : {}".format(backend))
 
-        # Loop through functions
-        for _f in real_x:
-            timings = []
-            for _ in range(n_trials):
-                start_time = time.time()
-                fs_interpn(diric_FS, T=[T, T], a=[a, a], b=[b, b], M=[M, M], real_x=real_x[_f])
-                timings.append(time.time() - start_time)
-            proc_time[N_FS][_f] = np.mean(timings)
-            proc_time_std[N_FS][_f] = np.std(timings)
-            print("{} version : {} seconds".format(_f, proc_time[N_FS][_f]))
+            # compute FS coefficients
+            diric_FS = mod.outer(
+                dirichlet_fs(N_FS, T, T_c, mod=mod), dirichlet_fs(N_FS, T, T_c, mod=mod)
+            )
+
+            # Loop through functions
+            for _f in real_x:
+                _key = "{}_{}".format(_f, backend)
+                timings = []
+                for _ in range(n_trials):
+                    start_time = time.time()
+                    fs_interpn(diric_FS, T=[T, T], a=[a, a], b=[b, b], M=[M, M], real_x=real_x[_f])
+                    timings.append(time.time() - start_time)
+                proc_time[N_FS][_key] = np.mean(timings)
+                proc_time_std[N_FS][_key] = np.std(timings)
+                print("{} version : {} seconds".format(_f, proc_time[N_FS][_key]))
 
     # plot results
     fig, ax = plt.subplots()
@@ -52,7 +62,7 @@ def profile_fs_interp2(n_trials):
     ax.set_xlabel("Number of FS coefficients per dimension")
     fig.tight_layout()
 
-    fname = pathlib.Path(__file__).resolve().parent / "fs_interp_2D_real_speedup.png"
+    fname = pathlib.Path(__file__).resolve().parent / "profile_fs_interp_2D.png"
     fig.savefig(fname, dpi=300)
 
 

--- a/profile/fs_interp2.py
+++ b/profile/fs_interp2.py
@@ -12,6 +12,40 @@ from pyffs.interp import fs_interpn
 from pyffs.backend import AVAILABLE_MOD, get_module_name
 
 
+def naive_interp2d(diric_FS, T, a, b, M):
+
+    # create sample points
+    D = len(T)
+    sample_points = []
+    for d in range(D):
+        sh = [1] * D
+        sh[d] = M[d]
+        sample_points.append(
+            np.linspace(start=a[d], stop=b[d], num=M[d], endpoint=False).reshape(sh)
+        )
+
+    # initialize output
+    x_vals = np.linspace(start=a[0], stop=b[0], num=M[0], endpoint=False)
+    y_vals = np.linspace(start=a[1], stop=b[1], num=M[1], endpoint=False)
+    output_shape = (len(x_vals), len(y_vals))
+    vals = np.zeros(output_shape, dtype=complex)
+
+    # loop to avoid creating potentially large matrices
+    N_FSx, N_FSy = diric_FS.shape
+    Kx = N_FSx // 2
+    Ky = N_FSy // 2
+    fsx_idx = np.arange(-Kx, Kx + 1)[:, np.newaxis]
+    fsy_idx = np.arange(-Ky, Ky + 1)[np.newaxis, :]
+    for i, _x_val in enumerate(x_vals):
+        for j, _y_val in enumerate(y_vals):
+            vals[i, j] = np.sum(
+                diric_FS
+                * np.exp(1j * 2 * np.pi * fsx_idx / T[0] * _x_val)
+                * np.exp(1j * 2 * np.pi * fsy_idx / T[1] * _y_val)
+            )
+    return vals
+
+
 @click.command()
 @click.option("--n_trials", type=int, default=10)
 def profile_fs_interp2(n_trials):
@@ -32,6 +66,18 @@ def profile_fs_interp2(n_trials):
         print("\nNumber of FS coefficients : {}".format(N_FS))
         proc_time[N_FS] = dict()
         proc_time_std[N_FS] = dict()
+
+        # naive approach
+        diric_FS = np.outer(dirichlet_fs(N_FS, T, T_c, mod=np), dirichlet_fs(N_FS, T, T_c, mod=np))
+        _key = "naive"
+        timings = []
+        for _ in range(n_trials):
+            start_time = time.time()
+            naive_interp2d(diric_FS, [T, T], [a, a], [b, b], [M, M])
+            timings.append(time.time() - start_time)
+        proc_time[N_FS][_key] = np.mean(timings)
+        proc_time_std[N_FS][_key] = np.std(timings)
+        print("-- {} : {} seconds".format(_key, proc_time[N_FS][_key]))
 
         # Loop through modules
         for mod in AVAILABLE_MOD:

--- a/pyffs/__init__.py
+++ b/pyffs/__init__.py
@@ -19,3 +19,5 @@ from .ffs import *
 from .interp import *
 from .util import *
 from . import func
+
+from .backend import *

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -14,7 +14,7 @@ Code is heavily inspired by `PyLops` library: https://github.com/PyLops/pylops/b
 import os
 from importlib import util
 import numpy as np
-from scipy import fftpack as fftpack
+from scipy import fftpack as fftpack  # TODO : replace with `scipy.fft`?
 
 
 cupy_enabled = util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYFFS", 1)) == 1
@@ -97,7 +97,7 @@ def get_array_module(x):
 
 def fftn(x, axes=None):
     """
-    Applies correct fftn module based on input.
+    Applies correct fftn method based on input.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def fftn(x, axes=None):
 
 def fft(x):
     """
-    Applies correct fft module based on input.
+    Applies correct fft method based on input.
 
     Parameters
     ----------
@@ -141,7 +141,7 @@ def fft(x):
 
 def ifftn(x, axes=None):
     """
-    Apply correct ifftn module based on input.
+    Apply correct ifftn method based on input.
 
     Parameters
     ----------
@@ -160,3 +160,24 @@ def ifftn(x, axes=None):
         return fftpack.ifftn(x, axes=axes)
     else:
         return cp.fft.ifftn(x, axes=axes)
+
+
+def next_fast_len(len):
+    """
+    Apply correct next_fast_len method based on backend.
+
+    Parameters
+    ----------
+    len : int
+        Desired FFT length.
+
+    Returns
+    -------
+    next_fast_len : int
+        next_fast_len >= len such that FFT computation is optimized.
+    """
+
+    if get_backend() == np:
+        return fftpack.next_fast_len(len)
+    else:
+        return cp.scipy.fft.next_fast_len(len)

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -17,10 +17,13 @@ import numpy as np
 from scipy import fftpack as fftpack  # TODO : replace with `scipy.fft`?
 
 
-cupy_enabled = util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYFFS", 1)) == 1
-if cupy_enabled:
+CUPY_ENABLED = util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYFFS", 1)) == 1
+AVAILABLE_MOD = [np]
+if CUPY_ENABLED:
     import cupy as cp
     import cupyx
+
+    AVAILABLE_MOD.append(cp)
 
 
 def get_module(backend="numpy"):
@@ -70,7 +73,7 @@ def get_module_name(mod):
 
 
 def get_backend():
-    if cupy_enabled:
+    if CUPY_ENABLED:
         return cp
     else:
         return np
@@ -90,7 +93,7 @@ def get_array_module(x):
     mod : :obj:`func`
         Module to be used to process array (:mod:`numpy` or :mod:`cupy`)
     """
-    if cupy_enabled:
+    if CUPY_ENABLED:
         return cp.get_array_module(x)
     else:
         return np

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -14,7 +14,7 @@ Code is heavily inspired by `PyLops` library: https://github.com/PyLops/pylops/b
 import os
 from importlib import util
 import numpy as np
-from scipy import fftpack as fftpack  # TODO : replace with `scipy.fft`?
+import scipy
 
 
 CUPY_ENABLED = util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYFFS", 1)) == 1
@@ -117,7 +117,7 @@ def fftn(x, axes=None):
     """
 
     if get_array_module(x) == np:
-        return fftpack.fftn(x, axes=axes)
+        return scipy.fft.fftn(x, axes=axes)
     else:
         return cupyx.scipy.fft.fftn(x, axes=axes)
 
@@ -138,7 +138,7 @@ def fft(x):
     """
 
     if get_array_module(x) == np:
-        return fftpack.fft(x)
+        return scipy.fft.fft(x)
     else:
         return cupyx.scipy.fft.fft(x)
 
@@ -161,27 +161,27 @@ def ifftn(x, axes=None):
     """
 
     if get_array_module(x) == np:
-        return fftpack.ifftn(x, axes=axes)
+        return scipy.fft.ifftn(x, axes=axes)
     else:
         return cupyx.scipy.fft.ifftn(x, axes=axes)
 
 
-def next_fast_len(len):
+def next_fast_len(target):
     """
     Apply correct next_fast_len method based on backend.
 
     Parameters
     ----------
-    len : int
+    target : int
         Desired FFT length.
 
     Returns
     -------
     next_fast_len : int
-        next_fast_len >= len such that FFT computation is optimized.
+        The smallest fast length greater than or equal to `target`.
     """
 
     if get_backend() == np:
-        return fftpack.next_fast_len(len)
+        return scipy.fft.next_fast_len(target)
     else:
-        return cupyx.scipy.fft.next_fast_len(len)
+        return cupyx.scipy.fft.next_fast_len(target)

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -14,7 +14,7 @@ Code is heavily inspired by `PyLops` library: https://github.com/PyLops/pylops/b
 import os
 from importlib import util
 import numpy as np
-import scipy
+import scipy.fft
 
 
 CUPY_ENABLED = util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYFFS", 1)) == 1

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -118,6 +118,27 @@ def fftn(x, axes=None):
         return cp.fft.fftn(x, axes=axes)
 
 
+def fft(x):
+    """
+    Applies correct fft module based on input.
+
+    Parameters
+    ----------
+    x : :obj:`numpy.ndarray` or :obj:`cupy.ndarray`
+        Array
+
+    Returns
+    -------
+    mod : :obj:`func`
+        Module to be used to process array (:mod:`numpy` or :mod:`cupy`)
+    """
+
+    if get_array_module(x) == np:
+        return fftpack.fft(x)
+    else:
+        return cp.fft.fft(x)
+
+
 def ifftn(x, axes=None):
     """
     Apply correct ifftn module based on input.

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -1,0 +1,87 @@
+# #############################################################################
+# backend.py
+# ==========
+# Authors :
+# Eric Bezzam [ebezzam@gmail.com]
+# #############################################################################
+
+"""
+Methods for identifying the appropriate backend between `numpy` and `cupy`.
+
+Code is heavily inspired by `PyLops` library: https://github.com/PyLops/pylops/blob/master/pylops/utils/backend.py
+"""
+
+import os
+from importlib import util
+import numpy as np
+
+
+cupy_enabled = util.find_spec("cupy") is not None and int(os.getenv('CUPY_PYFFS', 1)) == 1
+if cupy_enabled:
+    import cupy as cp
+
+
+def get_module(backend="numpy"):
+    """
+    Returns correct numerical module based on backend string.
+
+    Parameters
+    ----------
+    backend : :obj:`str`, optional
+        Backend used for computations (``numpy`` or ``cupy``).
+
+    Returns
+    -------
+    mod : :obj:`func`
+        Module to be used to process arrays (:mod:`numpy` or :mod:`cupy`).
+    """
+    if backend == "numpy":
+        xp = np
+    elif backend == "cupy":
+        xp = cp
+    else:
+        raise ValueError("backend must be `numpy` or `cupy`")
+    return xp
+
+
+def get_module_name(mod):
+    """
+    Returns name of numerical module based on input numerical module.
+
+    Parameters
+    ----------
+    mod : :obj:`func`
+        Module to be used to process array (:mod:`numpy` or :mod:`cupy`).
+
+    Returns
+    -------
+    backend : :obj:`str`, optional
+        Backend used for dot test computations (``numpy`` or ``cupy``).
+    """
+    if mod == np:
+        backend = "numpy"
+    elif mod == cp:
+        backend = "cupy"
+    else:
+        raise ValueError("module must be `numpy` or `cupy`")
+    return backend
+
+
+def get_array_module(x):
+    """
+    Returns correct numerical module based on input.
+
+    Parameters
+    ----------
+    x : :obj:`numpy.ndarray` or :obj:`cupy.ndarray`
+        Array
+
+    Returns
+    -------
+    mod : :obj:`func`
+        Module to be used to process array (:mod:`numpy` or :mod:`cupy`)
+    """
+    if cupy_enabled:
+        return cp.get_array_module(x)
+    else:
+        return np

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -116,7 +116,7 @@ def fftn(x, axes=None):
     if get_array_module(x) == np:
         return fftpack.fftn(x, axes=axes)
     else:
-        return cp.fft.fftn(x, axes=axes)
+        return cupyx.scipy.fft.fftn(x, axes=axes)
 
 
 def fft(x):
@@ -137,7 +137,7 @@ def fft(x):
     if get_array_module(x) == np:
         return fftpack.fft(x)
     else:
-        return cp.fft.fft(x)
+        return cupyx.scipy.fft.fft(x)
 
 
 def ifftn(x, axes=None):
@@ -160,7 +160,7 @@ def ifftn(x, axes=None):
     if get_array_module(x) == np:
         return fftpack.ifftn(x, axes=axes)
     else:
-        return cp.fft.ifftn(x, axes=axes)
+        return cupyx.scipy.fft.ifftn(x, axes=axes)
 
 
 def next_fast_len(len):

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -20,6 +20,7 @@ from scipy import fftpack as fftpack  # TODO : replace with `scipy.fft`?
 cupy_enabled = util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYFFS", 1)) == 1
 if cupy_enabled:
     import cupy as cp
+    import cupyx
 
 
 def get_module(backend="numpy"):
@@ -180,4 +181,4 @@ def next_fast_len(len):
     if get_backend() == np:
         return fftpack.next_fast_len(len)
     else:
-        return cp.scipy.fft.next_fast_len(len)
+        return cupyx.scipy.fft.next_fast_len(len)

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -166,7 +166,7 @@ def ifftn(x, axes=None):
         return cupyx.scipy.fft.ifftn(x, axes=axes)
 
 
-def next_fast_len(target):
+def next_fast_len(target, mod=None):
     """
     Apply correct next_fast_len method based on backend.
 
@@ -174,6 +174,8 @@ def next_fast_len(target):
     ----------
     target : int
         Desired FFT length.
+    mod : :obj:`func`
+        Module to be used to process array (:mod:`numpy` or :mod:`cupy`).
 
     Returns
     -------
@@ -181,7 +183,10 @@ def next_fast_len(target):
         The smallest fast length greater than or equal to `target`.
     """
 
-    if get_backend() == np:
+    if mod is None:
+        mod = get_backend()
+
+    if mod == np:
         return scipy.fft.next_fast_len(target)
     else:
         return cupyx.scipy.fft.next_fast_len(target)

--- a/pyffs/backend.py
+++ b/pyffs/backend.py
@@ -14,9 +14,10 @@ Code is heavily inspired by `PyLops` library: https://github.com/PyLops/pylops/b
 import os
 from importlib import util
 import numpy as np
+from scipy import fftpack as fftpack
 
 
-cupy_enabled = util.find_spec("cupy") is not None and int(os.getenv('CUPY_PYFFS', 1)) == 1
+cupy_enabled = util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYFFS", 1)) == 1
 if cupy_enabled:
     import cupy as cp
 
@@ -67,6 +68,13 @@ def get_module_name(mod):
     return backend
 
 
+def get_backend():
+    if cupy_enabled:
+        return cp
+    else:
+        return np
+
+
 def get_array_module(x):
     """
     Returns correct numerical module based on input.
@@ -85,3 +93,49 @@ def get_array_module(x):
         return cp.get_array_module(x)
     else:
         return np
+
+
+def fftn(x, axes=None):
+    """
+    Applies correct fftn module based on input.
+
+    Parameters
+    ----------
+    x : :obj:`numpy.ndarray` or :obj:`cupy.ndarray`
+        Array
+    axes : tuple
+        Dimension of `x` along which to perform FFT.
+
+    Returns
+    -------
+    mod : :obj:`func`
+        Module to be used to process array (:mod:`numpy` or :mod:`cupy`)
+    """
+
+    if get_array_module(x) == np:
+        return fftpack.fftn(x, axes=axes)
+    else:
+        return cp.fft.fftn(x, axes=axes)
+
+
+def ifftn(x, axes=None):
+    """
+    Apply correct ifftn module based on input.
+
+    Parameters
+    ----------
+    x : :obj:`numpy.ndarray` or :obj:`cupy.ndarray`
+        Array
+    axes : tuple
+        Dimension of `x` along which to perform IFFT.
+
+    Returns
+    -------
+    mod : :obj:`func`
+        Module to be used to process array (:mod:`numpy` or :mod:`cupy`)
+    """
+
+    if get_array_module(x) == np:
+        return fftpack.ifftn(x, axes=axes)
+    else:
+        return cp.fft.ifftn(x, axes=axes)

--- a/pyffs/czt.py
+++ b/pyffs/czt.py
@@ -141,7 +141,7 @@ def cztn(x, A, W, M, axes=None):
     L = []
     n = []
     for d in range(D):
-        _L = next_fast_len(N[d] + M[d] - 1)
+        _L = next_fast_len(N[d] + M[d] - 1, mod=xp)
         L.append(_L)
         n.append(xp.arange(_L))
 

--- a/pyffs/czt.py
+++ b/pyffs/czt.py
@@ -178,9 +178,12 @@ def cztn(x, A, W, M, axes=None):
         _N = N[d]
         sh_L = [1] * x.ndim
         sh_L[axes[d]] = L[d]
-        v = np.zeros(L[d], dtype=complex)
-        v[: M[d]] = np.float_power(W[d], -(n[d][: M[d]] ** 2) / 2)
-        v[L[d] - _N + 1 :] = np.float_power(W[d], -((L[d] - n[d][L[d] - _N + 1 :]) ** 2) / 2)
+        v = xp.zeros(L[d], dtype=complex)
+        # TODO : float_power not supported by cupy as of April 14, 2021
+        # v[: M[d]] = np.float_power(W[d], -(n[d][: M[d]] ** 2) / 2)
+        # v[L[d] - _N + 1 :] = np.float_power(W[d], -((L[d] - n[d][L[d] - _N + 1 :]) ** 2) / 2)
+        v[: M[d]] = xp.power(W[d], -(n[d][: M[d]] ** 2) / 2)
+        v[L[d] - _N + 1 :] = xp.power(W[d], -((L[d] - n[d][L[d] - _N + 1 :]) ** 2) / 2)
         V = fftpack.fft(v).reshape(sh_L)  # TODO : change for cupy support
         U *= V
     g = ifftn(U, axes=axes)
@@ -192,7 +195,9 @@ def cztn(x, A, W, M, axes=None):
         _M = M[d]
         sh_M = [1] * x.ndim
         sh_M[axes[d]] = _M
-        g_mod = np.float_power(W[d], (_n[:_M] ** 2) / 2)
+        # TODO : float_power not supported by cupy as of April 14, 2021
+        # g_mod = np.float_power(W[d], (_n[:_M] ** 2) / 2)
+        g_mod = xp.power(W[d], (_n[:_M] ** 2) / 2)
         g[time_idx] *= g_mod.reshape(sh_M)
 
     x_czt = g[time_idx]

--- a/pyffs/czt.py
+++ b/pyffs/czt.py
@@ -167,7 +167,9 @@ def cztn(x, A, W, M, axes=None):
         _N = N[d]
         sh_N = [1] * x.ndim
         sh_N[axes[d]] = N[d]
-        u_mod_d = (A[d] ** -_n[:_N]) * np.float_power(W[d], (_n[:_N] ** 2) / 2)
+        # TODO : float_power not supported by cupy as of April 14, 2021
+        # u_mod_d = (A[d] ** -_n[:_N]) * np.float_power(W[d], (_n[:_N] ** 2) / 2)
+        u_mod_d = (A[d] ** -_n[:_N]) * xp.power(W[d], (_n[:_N] ** 2) / 2)
         u[idx] *= u_mod_d.reshape(sh_N)
     U = fftn(u, axes=axes)
 

--- a/pyffs/czt.py
+++ b/pyffs/czt.py
@@ -16,6 +16,7 @@ import numpy as np
 from scipy import fftpack as fftpack
 
 from pyffs.util import _verify_cztn_input, _index_n
+from pyffs.backend import get_array_module, fftn, ifftn
 
 
 def czt(x, A, W, M, axis=-1):
@@ -135,6 +136,8 @@ def cztn(x, A, W, M, axes=None):
     """
     axes, A, W = _verify_cztn_input(x, A, W, M, axes)
 
+    xp = get_array_module(x)
+
     # Initialize variables
     D = len(axes)
     N = np.array(x.shape)[axes]
@@ -143,7 +146,7 @@ def cztn(x, A, W, M, axes=None):
     for d in range(D):
         _L = fftpack.next_fast_len(N[d] + M[d] - 1)
         L.append(_L)
-        n.append(np.arange(_L))
+        n.append(xp.arange(_L))
 
     # Initialize input
     sh_U = list(x.shape)
@@ -154,7 +157,7 @@ def cztn(x, A, W, M, axes=None):
         if ((x.dtype == np.dtype("complex64")) or (x.dtype == np.dtype("float32")))
         else np.complex128
     )
-    u = np.zeros(sh_U, dtype=dtype_u)
+    u = xp.zeros(sh_U, dtype=dtype_u)
     idx = _index_n(u, axes, [slice(n) for n in N])
     u[idx] = x
 
@@ -166,7 +169,7 @@ def cztn(x, A, W, M, axes=None):
         sh_N[axes[d]] = N[d]
         u_mod_d = (A[d] ** -_n[:_N]) * np.float_power(W[d], (_n[:_N] ** 2) / 2)
         u[idx] *= u_mod_d.reshape(sh_N)
-    U = fftpack.fftn(u, axes=axes)
+    U = fftn(u, axes=axes)
 
     # Convolve along each dimension -> multiply in frequency domain
     for d in range(D):
@@ -176,9 +179,9 @@ def cztn(x, A, W, M, axes=None):
         v = np.zeros(L[d], dtype=complex)
         v[: M[d]] = np.float_power(W[d], -(n[d][: M[d]] ** 2) / 2)
         v[L[d] - _N + 1 :] = np.float_power(W[d], -((L[d] - n[d][L[d] - _N + 1 :]) ** 2) / 2)
-        V = fftpack.fft(v).reshape(sh_L)
+        V = fftpack.fft(v).reshape(sh_L)  # TODO : change for cupy support
         U *= V
-    g = fftpack.ifftn(U, axes=axes)
+    g = ifftn(U, axes=axes)
 
     # Final modulation in time
     time_idx = _index_n(g, axes, [slice(m) for m in M])

--- a/pyffs/czt.py
+++ b/pyffs/czt.py
@@ -16,7 +16,7 @@ import numpy as np
 from scipy import fftpack as fftpack
 
 from pyffs.util import _verify_cztn_input, _index_n
-from pyffs.backend import get_array_module, fftn, ifftn
+from pyffs.backend import get_array_module, fftn, ifftn, fft
 
 
 def czt(x, A, W, M, axis=-1):
@@ -184,7 +184,7 @@ def cztn(x, A, W, M, axes=None):
         # v[L[d] - _N + 1 :] = np.float_power(W[d], -((L[d] - n[d][L[d] - _N + 1 :]) ** 2) / 2)
         v[: M[d]] = xp.power(W[d], -(n[d][: M[d]] ** 2) / 2)
         v[L[d] - _N + 1 :] = xp.power(W[d], -((L[d] - n[d][L[d] - _N + 1 :]) ** 2) / 2)
-        V = fftpack.fft(v).reshape(sh_L)  # TODO : change for cupy support
+        V = fft(v).reshape(sh_L)
         U *= V
     g = ifftn(U, axes=axes)
 

--- a/pyffs/czt.py
+++ b/pyffs/czt.py
@@ -12,11 +12,8 @@ Methods for computing the chirp Z-transform.
 
 __all__ = ["czt", "cztn", "_cztn"]
 
-import numpy as np
-from scipy import fftpack as fftpack
-
 from pyffs.util import _verify_cztn_input, _index_n
-from pyffs.backend import get_array_module, fftn, ifftn, fft
+from pyffs.backend import get_array_module, fftn, ifftn, fft, next_fast_len
 
 
 def czt(x, A, W, M, axis=-1):
@@ -140,11 +137,11 @@ def cztn(x, A, W, M, axes=None):
 
     # Initialize variables
     D = len(axes)
-    N = np.array(x.shape)[axes]
+    N = [x.shape[d] for d in axes]
     L = []
     n = []
     for d in range(D):
-        _L = fftpack.next_fast_len(N[d] + M[d] - 1)
+        _L = next_fast_len(N[d] + M[d] - 1)
         L.append(_L)
         n.append(xp.arange(_L))
 
@@ -153,9 +150,9 @@ def cztn(x, A, W, M, axes=None):
     for d in range(D):
         sh_U[axes[d]] = L[d]
     dtype_u = (
-        np.complex64
-        if ((x.dtype == np.dtype("complex64")) or (x.dtype == np.dtype("float32")))
-        else np.complex128
+        xp.complex64
+        if ((x.dtype == xp.dtype("complex64")) or (x.dtype == xp.dtype("float32")))
+        else xp.complex128
     )
     u = xp.zeros(sh_U, dtype=dtype_u)
     idx = _index_n(u, axes, [slice(n) for n in N])

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -13,7 +13,7 @@ Methods for computing Fast Fourier Series.
 __all__ = ["ffs", "ffsn", "iffs", "iffsn", "_ffsn", "_iffsn"]
 
 from pyffs.util import _create_modulation_vectors, _verify_ffsn_input, _modulate_2d
-from pyffs.backend import fftn, ifftn, get_array_module
+from pyffs.backend import fftn, ifftn, get_array_module, get_module_name
 
 
 def ffs(x, T, T_c, N_FS, axis=-1):
@@ -234,6 +234,8 @@ def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
     axes, N_s = _verify_ffsn_input(x, T, T_c, N_FS, axes)
 
     xp = get_array_module(x)
+    if get_module_name(xp) == "numpy":
+        fuse = False
 
     # check for input type
     if (x.dtype == xp.dtype("complex64")) or (x.dtype == xp.dtype("float32")):

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -243,7 +243,7 @@ def ffsn(x, T, T_c, N_FS, axes=None):
     # apply pre-FFT modulation
     A = []
     for d, N_sd in enumerate(N_s):
-        A_d, B_d = _create_modulation_vectors(N_sd, N_FS[d], T[d], T_c[d])
+        A_d, B_d = _create_modulation_vectors(N_sd, N_FS[d], T[d], T_c[d], xp)
         A.append(A_d.conj())
         sh = [1] * x.ndim
         sh[axes[d]] = N_s[d]
@@ -315,7 +315,7 @@ def iffsn(x_FS, T, T_c, N_FS, axes=None):
     # apply pre-iFFT modulation
     B = []
     for d, N_sd in enumerate(N_s):
-        A_d, B_d = _create_modulation_vectors(N_sd, N_FS[d], T[d], T_c[d])
+        A_d, B_d = _create_modulation_vectors(N_sd, N_FS[d], T[d], T_c[d], xp)
         B.append(B_d)
         sh = [1] * x.ndim
         sh[axes[d]] = N_s[d]

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -259,7 +259,6 @@ def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
 
     # apply pre-FFT modulation
     if D == 2 and fuse:
-        # TODO : really worth it just for 2D?
         x_FS = _modulate_2d(x_FS, C_2[0], C_2[1])
     else:
         for _c2 in C_2:
@@ -342,7 +341,6 @@ def iffsn(x_FS, T, T_c, N_FS, axes=None, fuse=True):
 
     # apply pre-FFT modulation
     if D == 2 and fuse:
-        # TODO : really worth it just for 2D?
         x = _modulate_2d(x, C_1[0], C_1[1])
     else:
         for _c1 in C_1:

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -12,10 +12,8 @@ Methods for computing Fast Fourier Series.
 
 __all__ = ["ffs", "ffsn", "iffs", "iffsn", "_ffsn", "_iffsn"]
 
-import numpy as np
-
 from pyffs.util import _create_modulation_vectors, _verify_ffsn_input
-from pyffs.backend import fftn, ifftn
+from pyffs.backend import fftn, ifftn, get_array_module
 
 
 def ffs(x, T, T_c, N_FS, axis=-1):
@@ -232,13 +230,15 @@ def ffsn(x, T, T_c, N_FS, axes=None):
     """
     axes, N_s = _verify_ffsn_input(x, T, T_c, N_FS, axes)
 
+    xp = get_array_module(x)
+
     # check for input type
-    if (x.dtype == np.dtype("complex64")) or (x.dtype == np.dtype("float32")):
+    if (x.dtype == xp.dtype("complex64")) or (x.dtype == xp.dtype("float32")):
         is_complex64 = True
-        x_FS = x.copy().astype(np.complex64)
+        x_FS = x.copy().astype(xp.complex64)
     else:
         is_complex64 = False
-        x_FS = x.copy().astype(np.complex128)
+        x_FS = x.copy().astype(xp.complex128)
 
     # apply pre-FFT modulation
     A = []
@@ -249,7 +249,7 @@ def ffsn(x, T, T_c, N_FS, axes=None):
         sh[axes[d]] = N_s[d]
         C_2 = B_d.conj().reshape(sh)
         if is_complex64:
-            C_2 = C_2.astype(np.complex64)
+            C_2 = C_2.astype(xp.complex64)
         x_FS *= C_2
 
     # apply post-FFT modulation
@@ -302,13 +302,15 @@ def iffsn(x_FS, T, T_c, N_FS, axes=None):
     """
     axes, N_s = _verify_ffsn_input(x_FS, T, T_c, N_FS, axes)
 
+    xp = get_array_module(x_FS)
+
     # check for input type
-    if (x_FS.dtype == np.dtype("complex64")) or (x_FS.dtype == np.dtype("float32")):
+    if (x_FS.dtype == xp.dtype("complex64")) or (x_FS.dtype == xp.dtype("float32")):
         is_complex64 = True
-        x = x_FS.copy().astype(np.complex64)
+        x = x_FS.copy().astype(xp.complex64)
     else:
         is_complex64 = False
-        x = x_FS.copy().astype(np.complex128)
+        x = x_FS.copy().astype(xp.complex128)
 
     # apply pre-iFFT modulation
     B = []
@@ -319,7 +321,7 @@ def iffsn(x_FS, T, T_c, N_FS, axes=None):
         sh[axes[d]] = N_s[d]
         C_1 = A_d.reshape(sh)
         if is_complex64:
-            C_1 = C_1.astype(np.complex64)
+            C_1 = C_1.astype(xp.complex64)
         x *= C_1
 
     # apply FFT

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -246,7 +246,7 @@ def ffsn(x, T, T_c, N_FS, axes=None):
         A_d, B_d = _create_modulation_vectors(N_sd, N_FS[d], T[d], T_c[d])
         A.append(A_d.conj())
         sh = [1] * x.ndim
-        sh[axes[d]] = N_s[d]
+        sh[axes[d]] = int(N_s[d])
         C_2 = B_d.conj().reshape(sh)
         if is_complex64:
             C_2 = C_2.astype(np.complex64)
@@ -258,9 +258,9 @@ def ffsn(x, T, T_c, N_FS, axes=None):
     # apply modulation after FFT
     for d, ax in enumerate(axes):
         sh = [1] * x.ndim
-        sh[ax] = N_s[d]
+        sh[ax] = int(N_s[d])
         C_1 = A[d].reshape(sh)
-        x_FS *= C_1 / N_s[d]
+        x_FS *= C_1 / int(N_s[d])
 
     return x_FS
 

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -16,7 +16,7 @@ from pyffs.util import _create_modulation_vectors, _verify_ffsn_input, _modulate
 from pyffs.backend import fftn, ifftn, get_array_module, get_module_name
 
 
-def ffs(x, T, T_c, N_FS, axis=-1):
+def ffs(x, T, T_c, N_FS, axis=-1, fuse=True):
     r"""
     Fourier Series coefficients from signal samples of a 1D function.
 
@@ -33,6 +33,9 @@ def ffs(x, T, T_c, N_FS, axis=-1):
         Function bandwidth.
     axis : int
         Dimension of `x` along which function samples are stored.
+    fuse : bool, optional
+        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
+        specify whether or not to fuse kernels for slight speedup.
 
     Returns
     -------
@@ -96,10 +99,10 @@ def ffs(x, T, T_c, N_FS, axis=-1):
     --------
     :py:func:`~pyffs.util.ffs_sample`, :py:func:`~pyffs.ffs.iffs`
     """
-    return ffsn(x=x, T=[T], T_c=[T_c], N_FS=[N_FS], axes=(axis,))
+    return ffsn(x=x, T=[T], T_c=[T_c], N_FS=[N_FS], axes=(axis,), fuse=fuse)
 
 
-def iffs(x_FS, T, T_c, N_FS, axis=-1):
+def iffs(x_FS, T, T_c, N_FS, axis=-1, fuse=True):
     r"""
     Signal samples from Fourier Series coefficients of a 1D function.
 
@@ -118,6 +121,9 @@ def iffs(x_FS, T, T_c, N_FS, axis=-1):
         Function bandwidth.
     axis : int
         Dimension of `x_FS` along which FS coefficients are stored.
+    fuse : bool, optional
+        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
+        specify whether or not to fuse kernels for slight speedup.
 
     Returns
     -------
@@ -135,7 +141,7 @@ def iffs(x_FS, T, T_c, N_FS, axis=-1):
     --------
     :py:func:`~pyffs.util.ffs_sample`, :py:func:`~pyffs.ffs.ffs`
     """
-    return iffsn(x_FS=x_FS, T=[T], T_c=[T_c], N_FS=[N_FS], axes=(axis,))
+    return iffsn(x_FS=x_FS, T=[T], T_c=[T_c], N_FS=[N_FS], axes=(axis,), fuse=fuse)
 
 
 def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -13,9 +13,9 @@ Methods for computing Fast Fourier Series.
 __all__ = ["ffs", "ffsn", "iffs", "iffsn", "_ffsn", "_iffsn"]
 
 import numpy as np
-from scipy import fftpack as fftpack
 
 from pyffs.util import _create_modulation_vectors, _verify_ffsn_input
+from pyffs.backend import fftn, ifftn
 
 
 def ffs(x, T, T_c, N_FS, axis=-1):
@@ -253,7 +253,7 @@ def ffsn(x, T, T_c, N_FS, axes=None):
         x_FS *= C_2
 
     # apply post-FFT modulation
-    x_FS = fftpack.fftn(x_FS, axes=axes)
+    x_FS = fftn(x_FS, axes=axes)
 
     # apply modulation after FFT
     for d, ax in enumerate(axes):
@@ -323,7 +323,7 @@ def iffsn(x_FS, T, T_c, N_FS, axes=None):
         x *= C_1
 
     # apply FFT
-    x = fftpack.ifftn(x, axes=axes)
+    x = ifftn(x, axes=axes)
 
     # apply post-iFFT modulation
     for d, ax in enumerate(axes):

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -318,6 +318,8 @@ def iffsn(x_FS, T, T_c, N_FS, axes=None, fuse=True):
     axes, N_s = _verify_ffsn_input(x_FS, T, T_c, N_FS, axes)
 
     xp = get_array_module(x_FS)
+    if get_module_name(xp) == "numpy":
+        fuse = False
 
     # check for input type
     if (x_FS.dtype == xp.dtype("complex64")) or (x_FS.dtype == xp.dtype("float32")):

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -246,7 +246,7 @@ def ffsn(x, T, T_c, N_FS, axes=None):
         A_d, B_d = _create_modulation_vectors(N_sd, N_FS[d], T[d], T_c[d])
         A.append(A_d.conj())
         sh = [1] * x.ndim
-        sh[axes[d]] = int(N_s[d])
+        sh[axes[d]] = N_s[d]
         C_2 = B_d.conj().reshape(sh)
         if is_complex64:
             C_2 = C_2.astype(np.complex64)
@@ -258,9 +258,9 @@ def ffsn(x, T, T_c, N_FS, axes=None):
     # apply modulation after FFT
     for d, ax in enumerate(axes):
         sh = [1] * x.ndim
-        sh[ax] = int(N_s[d])
+        sh[ax] = N_s[d]
         C_1 = A[d].reshape(sh)
-        x_FS *= C_1 / int(N_s[d])
+        x_FS *= C_1 / N_s[d]
 
     return x_FS
 

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -243,7 +243,6 @@ def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
         is_complex64 = False
         x_FS = x.copy().astype(xp.complex128)
 
-    # TODO : really worth it just for 2D?
     # pre-compute modulation arrays
     C_1 = []
     C_2 = []
@@ -260,12 +259,11 @@ def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
 
     # apply pre-FFT modulation
     if D == 2 and fuse:
+        # TODO : really worth it just for 2D?
         x_FS = _modulate_2d(x_FS, C_2[0], C_2[1])
     else:
         for _c2 in C_2:
             x_FS *= _c2
-
-    # apply post-FFT modulation
     x_FS = fftn(x_FS, axes=axes)
 
     # apply modulation after FFT
@@ -275,32 +273,10 @@ def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
         for _c1 in C_1:
             x_FS *= _c1
 
-    # # apply pre-FFT modulation
-    # A = []
-    # for d, N_sd in enumerate(N_s):
-    #     A_d, B_d = _create_modulation_vectors(N_sd, N_FS[d], T[d], T_c[d], xp)
-    #     A.append(A_d.conj())
-    #     sh = [1] * x.ndim
-    #     sh[axes[d]] = N_s[d]
-    #     C_2 = B_d.conj().reshape(sh)
-    #     if is_complex64:
-    #         C_2 = C_2.astype(xp.complex64)
-    #     x_FS *= C_2
-    #
-    # # apply post-FFT modulation
-    # x_FS = fftn(x_FS, axes=axes)
-    #
-    # # apply modulation after FFT
-    # for d, ax in enumerate(axes):
-    #     sh = [1] * x.ndim
-    #     sh[ax] = N_s[d]
-    #     C_1 = A[d].reshape(sh)
-    #     x_FS *= C_1 / N_s[d]
-
     return x_FS
 
 
-def iffsn(x_FS, T, T_c, N_FS, axes=None):
+def iffsn(x_FS, T, T_c, N_FS, axes=None, fuse=True):
     r"""
     Signal samples from Fourier Series coefficients of a D-dimension signal.
 
@@ -318,6 +294,9 @@ def iffsn(x_FS, T, T_c, N_FS, axes=None):
         Function bandwidth along each dimension.
     axes : tuple
         Dimensions of `x_FS` along which FS coefficients are stored.
+    fuse : bool, optional
+        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
+        specify whether or not to fuse kernels for slight speedup.
 
     Returns
     -------
@@ -347,27 +326,35 @@ def iffsn(x_FS, T, T_c, N_FS, axes=None):
         is_complex64 = False
         x = x_FS.copy().astype(xp.complex128)
 
-    # apply pre-iFFT modulation
-    B = []
-    for d, N_sd in enumerate(N_s):
-        A_d, B_d = _create_modulation_vectors(N_sd, N_FS[d], T[d], T_c[d], xp)
-        B.append(B_d)
-        sh = [1] * x.ndim
-        sh[axes[d]] = N_s[d]
-        C_1 = A_d.reshape(sh)
-        if is_complex64:
-            C_1 = C_1.astype(xp.complex64)
-        x *= C_1
-
-    # apply FFT
-    x = ifftn(x, axes=axes)
-
-    # apply post-iFFT modulation
+    # pre-compute modulation arrays
+    C_1 = []
+    C_2 = []
+    D = len(axes)
     for d, ax in enumerate(axes):
+        A_d, B_d = _create_modulation_vectors(N_s[d], N_FS[d], T[d], T_c[d], xp)
         sh = [1] * x.ndim
         sh[ax] = N_s[d]
-        C_2 = B[d].reshape(sh)
-        x *= C_2 * N_s[d]
+        C_1.append(A_d.reshape(sh))
+        C_2.append(B_d.reshape(sh) * N_s[d])
+        if is_complex64:
+            C_1[d].astype(xp.complex64)
+            C_2[d].astype(xp.complex64)
+
+    # apply pre-FFT modulation
+    if D == 2 and fuse:
+        # TODO : really worth it just for 2D?
+        x = _modulate_2d(x, C_1[0], C_1[1])
+    else:
+        for _c1 in C_1:
+            x *= _c1
+    x = ifftn(x, axes=axes)
+
+    # apply modulation after FFT
+    if D == 2 and fuse:
+        x = _modulate_2d(x, C_2[0], C_2[1])
+    else:
+        for _c2 in C_2:
+            x *= _c2
 
     return x
 

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -155,6 +155,9 @@ def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
         Function bandwidth along each dimension.
     axes : tuple
         Dimensions of `x` along which function samples are stored.
+    fuse : bool, optional
+        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
+        specify whether or not to fuse kernels for slight speedup.
 
     Returns
     -------
@@ -256,7 +259,7 @@ def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
             C_2[d].astype(xp.complex64)
 
     # apply pre-FFT modulation
-    if D == 2:
+    if D == 2 and fuse:
         x_FS = _modulate_2d(x_FS, C_2[0], C_2[1])
     else:
         for _c2 in C_2:

--- a/pyffs/ffs.py
+++ b/pyffs/ffs.py
@@ -16,7 +16,7 @@ from pyffs.util import _create_modulation_vectors, _verify_ffsn_input, _modulate
 from pyffs.backend import fftn, ifftn, get_array_module, get_module_name
 
 
-def ffs(x, T, T_c, N_FS, axis=-1, fuse=True):
+def ffs(x, T, T_c, N_FS, axis=-1):
     r"""
     Fourier Series coefficients from signal samples of a 1D function.
 
@@ -33,9 +33,6 @@ def ffs(x, T, T_c, N_FS, axis=-1, fuse=True):
         Function bandwidth.
     axis : int
         Dimension of `x` along which function samples are stored.
-    fuse : bool, optional
-        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
-        specify whether or not to fuse kernels for slight speedup.
 
     Returns
     -------
@@ -99,10 +96,10 @@ def ffs(x, T, T_c, N_FS, axis=-1, fuse=True):
     --------
     :py:func:`~pyffs.util.ffs_sample`, :py:func:`~pyffs.ffs.iffs`
     """
-    return ffsn(x=x, T=[T], T_c=[T_c], N_FS=[N_FS], axes=(axis,), fuse=fuse)
+    return ffsn(x=x, T=[T], T_c=[T_c], N_FS=[N_FS], axes=(axis,), fuse=False)
 
 
-def iffs(x_FS, T, T_c, N_FS, axis=-1, fuse=True):
+def iffs(x_FS, T, T_c, N_FS, axis=-1):
     r"""
     Signal samples from Fourier Series coefficients of a 1D function.
 
@@ -121,9 +118,6 @@ def iffs(x_FS, T, T_c, N_FS, axis=-1, fuse=True):
         Function bandwidth.
     axis : int
         Dimension of `x_FS` along which FS coefficients are stored.
-    fuse : bool, optional
-        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
-        specify whether or not to fuse kernels for slight speedup.
 
     Returns
     -------
@@ -141,7 +135,7 @@ def iffs(x_FS, T, T_c, N_FS, axis=-1, fuse=True):
     --------
     :py:func:`~pyffs.util.ffs_sample`, :py:func:`~pyffs.ffs.ffs`
     """
-    return iffsn(x_FS=x_FS, T=[T], T_c=[T_c], N_FS=[N_FS], axes=(axis,), fuse=fuse)
+    return iffsn(x_FS=x_FS, T=[T], T_c=[T_c], N_FS=[N_FS], axes=(axis,), fuse=False)
 
 
 def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
@@ -162,7 +156,7 @@ def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
     axes : tuple
         Dimensions of `x` along which function samples are stored.
     fuse : bool, optional
-        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
+        Note that this is only taken into account for D=2 and when cupy is being used. In this case
         specify whether or not to fuse kernels for slight speedup.
 
     Returns
@@ -240,8 +234,6 @@ def ffsn(x, T, T_c, N_FS, axes=None, fuse=True):
     axes, N_s = _verify_ffsn_input(x, T, T_c, N_FS, axes)
 
     xp = get_array_module(x)
-    if get_module_name(xp) == "numpy":
-        fuse = False
 
     # check for input type
     if (x.dtype == xp.dtype("complex64")) or (x.dtype == xp.dtype("float32")):
@@ -302,7 +294,7 @@ def iffsn(x_FS, T, T_c, N_FS, axes=None, fuse=True):
     axes : tuple
         Dimensions of `x_FS` along which FS coefficients are stored.
     fuse : bool, optional
-        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
+        Note that this is only taken into account for D=2 and when cupy is being used. In this case
         specify whether or not to fuse kernels for slight speedup.
 
     Returns

--- a/pyffs/func.py
+++ b/pyffs/func.py
@@ -13,6 +13,8 @@ functions.
 
 import numpy as np
 
+from pyffs.backend import get_array_module, get_backend
+
 
 def dirichlet(x, T, T_c, N_FS):
     r"""
@@ -45,13 +47,15 @@ def dirichlet(x, T, T_c, N_FS):
     --------
     :py:func:`~pyffs.func.dirichlet_fs`
     """
+    xp = get_array_module(x)
+
     y = x - T_c
-    n, d = np.zeros((2, len(x)))
-    nan_mask = np.isclose(np.fmod(y, np.pi), 0)
-    n[~nan_mask] = np.sin(N_FS * np.pi * y[~nan_mask] / T)
-    d[~nan_mask] = np.sin(np.pi * y[~nan_mask] / T)
-    n[nan_mask] = N_FS * np.cos(N_FS * np.pi * y[nan_mask] / T)
-    d[nan_mask] = np.cos(np.pi * y[nan_mask] / T)
+    n, d = xp.zeros((2, len(x)))
+    nan_mask = xp.isclose(np.fmod(y, np.pi), 0)
+    n[~nan_mask] = xp.sin(N_FS * np.pi * y[~nan_mask] / T)
+    d[~nan_mask] = xp.sin(np.pi * y[~nan_mask] / T)
+    n[nan_mask] = N_FS * xp.cos(N_FS * np.pi * y[nan_mask] / T)
+    d[nan_mask] = xp.cos(np.pi * y[nan_mask] / T)
 
     return n / d
 
@@ -80,8 +84,9 @@ def dirichlet_fs(N_FS, T, T_c):
     :py:func:`~pyffs.func.dirichlet`
         (N_FS,) Fourier Series coefficients.
     """
+    xp = get_backend()
     N = (N_FS - 1) // 2
-    return np.exp(-1j * (2 * np.pi / T) * T_c * np.r_[-N : N + 1])
+    return xp.exp(-1j * (2 * np.pi / T) * T_c * np.arange(start=-N, stop=N + 1))
 
 
 def dirichlet_2D(sample_points, T, T_c, N_FS):
@@ -119,7 +124,9 @@ def dirichlet_2D(sample_points, T, T_c, N_FS):
     --------
     :py:func:`~pyffs.util.ffsn_sample`, :py:func:`~pyffs.func.dirichlet_fs`
     """
+    xp = get_array_module(sample_points)
+
     # compute along x and y, then combine
     x_vals = dirichlet(x=sample_points[0][:, 0], T=T[0], T_c=T_c[0], N_FS=N_FS[0])
     y_vals = dirichlet(x=sample_points[1][0, :], T=T[1], T_c=T_c[1], N_FS=N_FS[1])
-    return np.outer(x_vals, y_vals)
+    return xp.outer(x_vals, y_vals)

--- a/pyffs/func.py
+++ b/pyffs/func.py
@@ -11,8 +11,6 @@ Methods for computing samples and Fourier Series coefficients of specific
 functions.
 """
 
-import numpy as np
-
 from pyffs.backend import get_array_module, get_backend
 
 
@@ -51,11 +49,11 @@ def dirichlet(x, T, T_c, N_FS):
 
     y = x - T_c
     n, d = xp.zeros((2, len(x)))
-    nan_mask = xp.isclose(np.fmod(y, np.pi), 0)
-    n[~nan_mask] = xp.sin(N_FS * np.pi * y[~nan_mask] / T)
-    d[~nan_mask] = xp.sin(np.pi * y[~nan_mask] / T)
-    n[nan_mask] = N_FS * xp.cos(N_FS * np.pi * y[nan_mask] / T)
-    d[nan_mask] = xp.cos(np.pi * y[nan_mask] / T)
+    nan_mask = xp.isclose(xp.fmod(y, xp.pi), 0)
+    n[~nan_mask] = xp.sin(N_FS * xp.pi * y[~nan_mask] / T)
+    d[~nan_mask] = xp.sin(xp.pi * y[~nan_mask] / T)
+    n[nan_mask] = N_FS * xp.cos(N_FS * xp.pi * y[nan_mask] / T)
+    d[nan_mask] = xp.cos(xp.pi * y[nan_mask] / T)
 
     return n / d
 
@@ -86,7 +84,7 @@ def dirichlet_fs(N_FS, T, T_c):
     """
     xp = get_backend()
     N = (N_FS - 1) // 2
-    return xp.exp(-1j * (2 * np.pi / T) * T_c * xp.arange(start=-N, stop=N + 1))
+    return xp.exp(-1j * (2 * xp.pi / T) * T_c * xp.arange(start=-N, stop=N + 1))
 
 
 def dirichlet_2D(sample_points, T, T_c, N_FS):

--- a/pyffs/func.py
+++ b/pyffs/func.py
@@ -58,7 +58,7 @@ def dirichlet(x, T, T_c, N_FS):
     return n / d
 
 
-def dirichlet_fs(N_FS, T, T_c):
+def dirichlet_fs(N_FS, T, T_c, mod=None):
     """
     Return Fourier Series coefficients of a shifted Dirichlet kernel of period
     :math:`T` and bandwidth :math:`N_{FS} = 2 N + 1`.
@@ -71,6 +71,9 @@ def dirichlet_fs(N_FS, T, T_c):
         Function period.
     T_c : float
         Period mid-point.
+    mod : :obj:`func`
+        Module to be used to process array (:mod:`numpy` or :mod:`cupy`).
+
 
     Returns
     -------
@@ -82,9 +85,10 @@ def dirichlet_fs(N_FS, T, T_c):
     :py:func:`~pyffs.func.dirichlet`
         (N_FS,) Fourier Series coefficients.
     """
-    xp = get_backend()
+    if mod is None:
+        mod = get_backend()
     N = (N_FS - 1) // 2
-    return xp.exp(-1j * (2 * xp.pi / T) * T_c * xp.arange(start=-N, stop=N + 1))
+    return mod.exp(-1j * (2 * mod.pi / T) * T_c * mod.arange(start=-N, stop=N + 1))
 
 
 def dirichlet_2D(sample_points, T, T_c, N_FS):

--- a/pyffs/func.py
+++ b/pyffs/func.py
@@ -86,7 +86,7 @@ def dirichlet_fs(N_FS, T, T_c):
     """
     xp = get_backend()
     N = (N_FS - 1) // 2
-    return xp.exp(-1j * (2 * np.pi / T) * T_c * np.arange(start=-N, stop=N + 1))
+    return xp.exp(-1j * (2 * np.pi / T) * T_c * xp.arange(start=-N, stop=N + 1))
 
 
 def dirichlet_2D(sample_points, T, T_c, N_FS):

--- a/pyffs/interp.py
+++ b/pyffs/interp.py
@@ -203,7 +203,7 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False):
 
         if D == 1:
             x_FS_p = x_FS[_index(x_FS, axes[0], slice(N[0] + 1, N_FS[0]))]
-            C = np.reshape(W[0] ** E[0], sh[0]) / A[0]
+            C = xp.reshape(W[0] ** E[0], sh[0]) / A[0]
 
             x = czt(x_FS_p, A[0], W[0], M[0], axis=axes[0])
             x *= 2 * C

--- a/pyffs/interp.py
+++ b/pyffs/interp.py
@@ -196,7 +196,7 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False):
         W.append(np.exp(1j * (2 * np.pi / T[d]) * (b[d] - a[d]) / (M[d] - 1)))
         sh.append([1] * x_FS.ndim)
         sh[d][axes[d]] = M[d]
-        E.append(np.arange(M[d]))
+        E.append(xp.arange(M[d]))
 
     if real_x:
         x0_FS = x_FS[_index_n(x_FS, axes, [slice(n, n + 1) for n in N])]

--- a/pyffs/interp.py
+++ b/pyffs/interp.py
@@ -220,7 +220,10 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False, fuse=True):
             x = czt(x_FS_p, A[0], W[0], M[0], axis=axes[0])
 
             # exploit conjugate symmetry
-            x = _real_interpolation_1d(x0_FS, x, C)
+            if fuse:
+                x = _real_interpolation_1d(x0_FS, x, C)
+            else:
+                x = 2 * C * x + x0_FS
 
         elif D == 2:
             # positive / positive
@@ -234,7 +237,10 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False, fuse=True):
             x_np *= xp.reshape(W[1] ** E[1], sh[1]) / A[1]
 
             # exploit conjugate symmetry
-            x = _real_interpolation_2d(x0_FS, x_pp, x_np)
+            if fuse:
+                x = _real_interpolation_2d(x0_FS, x_pp, x_np)
+            else:
+                x = 2 * x_pp + 2 * x_np - x0_FS
         else:
             raise NotImplementedError("[real_x] approach not available for D > 2.")
 

--- a/pyffs/interp.py
+++ b/pyffs/interp.py
@@ -49,8 +49,8 @@ def fs_interp(x_FS, T, a, b, M, axis=-1, real_x=False, fuse=True):
         If True, assume that `x_FS` is conjugate symmetric and use a more efficient algorithm. In
         this case, the FS coefficients corresponding to negative frequencies are not used.
     fuse : bool, optional
-        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
-        specify whether or not to fuse kernels for slight speedup.
+        Note that this is only taken into account when cupy is being used. In this case specify
+        whether or not to fuse kernels for slight speedup.
 
     Returns
     -------
@@ -172,7 +172,7 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False, fuse=True):
         corresponding to negative frequencies are not used. Note that this
         approach is only available for D < 3, and will raise an error otherwise.
     fuse : bool, optional
-        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
+        Note that this is only taken into account for D<=2 and when cupy is being used. In this case
         specify whether or not to fuse kernels for slight speedup.
 
     Returns
@@ -194,8 +194,6 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False, fuse=True):
     D = len(axes)
 
     xp = get_array_module(x_FS)
-    if get_module_name(xp) == "numpy":
-        fuse = False
 
     # precompute modulation terms
     N_FS = [x_FS.shape[d] for d in axes]
@@ -232,7 +230,7 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False, fuse=True):
 
             # negative / positive
             x_FS_np = x_FS[_index_n(x_FS, axes, [slice(0, N[0]), slice(N[1] + 1, N_FS[1])])]
-            x_np = cztn(x_FS_np, A, W, M, axes=axes)
+            x_np = cztn(x_FS_np, A, W, M, axes=axes, fuse=fuse)
             x_np *= xp.reshape(W[0] ** (-N[0] * E[0]), sh[0]) * (A[0] ** N[0])
             x_np *= xp.reshape(W[1] ** E[1], sh[1]) / A[1]
 
@@ -246,7 +244,7 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False, fuse=True):
 
         return x.real
     else:  # General complex case.
-        x = cztn(x_FS, A, W, M, axes=axes)
+        x = cztn(x_FS, A, W, M, axes=axes, fuse=fuse)
 
         # modulate along each dimension
         if D == 2 and fuse:

--- a/pyffs/interp.py
+++ b/pyffs/interp.py
@@ -19,7 +19,7 @@ from pyffs.util import (
     _real_interpolation_1d,
     _real_interpolation_2d,
 )
-from pyffs.backend import get_array_module
+from pyffs.backend import get_array_module, get_module_name
 
 
 def fs_interp(x_FS, T, a, b, M, axis=-1, real_x=False):
@@ -191,6 +191,8 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False, fuse=True):
     D = len(axes)
 
     xp = get_array_module(x_FS)
+    if get_module_name(xp) == "numpy":
+        fuse = False
 
     # precompute modulation terms
     N_FS = [x_FS.shape[d] for d in axes]

--- a/pyffs/interp.py
+++ b/pyffs/interp.py
@@ -10,8 +10,6 @@
 Methods for interpolating functions using Fourier Series.
 """
 
-import numpy as np
-
 from pyffs.czt import czt, cztn
 from pyffs.util import _index, _index_n, _verify_fs_interp_input
 from pyffs.backend import get_array_module
@@ -185,15 +183,15 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False):
     xp = get_array_module(x_FS)
 
     # precompute modulation terms
-    N_FS = np.array(x_FS.shape)[list(axes)]
-    N = (N_FS - 1) // 2
+    N_FS = [x_FS.shape[d] for d in axes]
+    N = [(nfs - 1) // 2 for nfs in N_FS]
     A = []
     W = []
     sh = []
     E = []
     for d in range(D):
-        A.append(np.exp(-1j * 2 * np.pi / T[d] * a[d]))
-        W.append(np.exp(1j * (2 * np.pi / T[d]) * (b[d] - a[d]) / (M[d] - 1)))
+        A.append(xp.exp(-1j * 2 * xp.pi / T[d] * a[d]))
+        W.append(xp.exp(1j * (2 * xp.pi / T[d]) * (b[d] - a[d]) / (M[d] - 1)))
         sh.append([1] * x_FS.ndim)
         sh[d][axes[d]] = M[d]
         E.append(xp.arange(M[d]))
@@ -216,8 +214,8 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False):
             # negative / positive
             x_FS_np = x_FS[_index_n(x_FS, axes, [slice(0, N[0]), slice(N[1] + 1, N_FS[1])])]
             x_np = cztn(x_FS_np, A, W, M, axes=axes)
-            x_np *= np.reshape(W[0] ** (-N[0] * E[0]), sh[0]) * (A[0] ** N[0])
-            x_np *= np.reshape(W[1] ** E[1], sh[1]) / A[1]
+            x_np *= xp.reshape(W[0] ** (-N[0] * E[0]), sh[0]) * (A[0] ** N[0])
+            x_np *= xp.reshape(W[1] ** E[1], sh[1]) / A[1]
 
             # exploit conjugate symmetry
             x = 2 * x_pp - x0_FS + 2 * x_np

--- a/pyffs/interp.py
+++ b/pyffs/interp.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from pyffs.czt import czt, cztn
 from pyffs.util import _index, _index_n, _verify_fs_interp_input
+from pyffs.backend import get_array_module
 
 
 def fs_interp(x_FS, T, a, b, M, axis=-1, real_x=False):
@@ -181,6 +182,8 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False):
     axes = _verify_fs_interp_input(x_FS, T, a, b, M, axes)
     D = len(axes)
 
+    xp = get_array_module(x_FS)
+
     # precompute modulation terms
     N_FS = np.array(x_FS.shape)[list(axes)]
     N = (N_FS - 1) // 2
@@ -227,7 +230,7 @@ def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False):
 
         # modulate along each dimension
         for d in range(D):
-            C = np.reshape(W[d] ** (-N[d] * E[d]), sh[d]) * (A[d] ** N[d])
+            C = xp.reshape(W[d] ** (-N[d] * E[d]), sh[d]) * (A[d] ** N[d])
             x *= C
 
         return x

--- a/pyffs/interp.py
+++ b/pyffs/interp.py
@@ -22,7 +22,7 @@ from pyffs.util import (
 from pyffs.backend import get_array_module, get_module_name
 
 
-def fs_interp(x_FS, T, a, b, M, axis=-1, real_x=False):
+def fs_interp(x_FS, T, a, b, M, axis=-1, real_x=False, fuse=True):
     r"""
     Interpolate bandlimited periodic signal.
 
@@ -48,6 +48,9 @@ def fs_interp(x_FS, T, a, b, M, axis=-1, real_x=False):
     real_x : bool, optional
         If True, assume that `x_FS` is conjugate symmetric and use a more efficient algorithm. In
         this case, the FS coefficients corresponding to negative frequencies are not used.
+    fuse : bool, optional
+        Note that this is only taken intro account for D=2 and when cupy is being used. In this case
+        specify whether or not to fuse kernels for slight speedup.
 
     Returns
     -------
@@ -142,7 +145,7 @@ def fs_interp(x_FS, T, a, b, M, axis=-1, real_x=False):
     --------
     :py:func:`~pyffs.czt.czt`, :py:func:`~pyffs.interp.fs_interpn`
     """
-    return fs_interpn(x_FS=x_FS, T=[T], a=[a], b=[b], M=[M], axes=(axis,), real_x=real_x)
+    return fs_interpn(x_FS=x_FS, T=[T], a=[a], b=[b], M=[M], axes=(axis,), real_x=real_x, fuse=fuse)
 
 
 def fs_interpn(x_FS, T, a, b, M, axes=None, real_x=False, fuse=True):

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -424,15 +424,9 @@ def _create_modulation_vectors(N_s, N_FS, T, T_c):
     :py:func:`~pyffs.ffs.ffsn`, :py:func:`~pyffs.ffs.iffsn`
     """
     xp = get_backend()
-    M = N_s // 2
-    N = N_FS // 2
-
-    fs_idx = xp.arange(start=-N, stop=N + 1)
-    zero_pad = xp.zeros((int(N_s) - N_FS,), dtype=xp.int)
-    E_1 = xp.concatenate((fs_idx, zero_pad))
-
-    # E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros(N_s - N_FS, dtype=xp.int)]
-
+    M = int(N_s // 2)
+    N = int(N_FS // 2)
+    E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros(N_s - N_FS, dtype=int)]
     B_2 = xp.exp(-1j * 2 * xp.pi / N_s)
 
     if N_s % 2 == 1:

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -426,7 +426,7 @@ def _create_modulation_vectors(N_s, N_FS, T, T_c):
     xp = get_backend()
     M = N_s // 2
     N = N_FS // 2
-    E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros((N_s - N_FS,), dtype=int)]
+    E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros(N_s - N_FS, dtype=xp.int)]
     B_2 = xp.exp(-1j * 2 * xp.pi / N_s)
 
     if N_s % 2 == 1:

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -12,8 +12,7 @@ Helper functions.
 
 import cmath
 
-import numpy as np
-from pyffs.backend import get_backend, get_array_module
+from pyffs.backend import get_backend
 
 
 def _index(x, axis, index_spec):
@@ -215,7 +214,7 @@ def _verify_ffsn_input(x, T, T_c, N_FS, axes):
     else:
         axes = list(range(D))
 
-    N_s = np.array(x.shape)[axes]
+    N_s = [x.shape[d] for d in axes]
 
     # check valid values
     for d in range(D):
@@ -225,30 +224,6 @@ def _verify_ffsn_input(x, T, T_c, N_FS, axes):
             raise ValueError(f"Parameter[N_FS[d]] must lie in {{3, ..., N_s[d]}}.")
 
     return tuple(axes), N_s
-
-
-def cartesian_product(x1, x2):
-    """
-    Return
-    `Cartesian product <https://en.wikipedia.org/wiki/Cartesian_product>`_ of two arrays.
-
-    Parameters
-    ----------
-    x1 : :py:class:`~numpy.ndarray`
-        (M,) array.
-    x2 : :py:class:`~numpy.ndarray`
-        (N,) array.
-
-    Returns
-    -------
-    y : :py:class:`~numpy.ndarray`
-        (M, N, 2) array.
-    """
-    sh = len(x1), len(x2)
-    y = np.stack(
-        [np.broadcast_to(x1.reshape(-1, 1), sh), np.broadcast_to(x2.reshape(1, -1), sh)], axis=-1
-    )
-    return y
 
 
 def ffs_sample(T, N_FS, T_c, N_s):

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -434,7 +434,7 @@ def _modulate_2d(x, y1, y2):
 if CUPY_ENABLED:
     import cupy as cp
 
-    # _modulate_2d = cp.fuse(_modulate_2d)
-    _modulate_2d = foo = cp.ElementwiseKernel(
-        "S y1, S y2", "S x", "x = x * y1 * y2", "_modulate_2d"  # overwrite x
-    )
+    _modulate_2d = cp.fuse(_modulate_2d)
+    # _modulate_2d = foo = cp.ElementwiseKernel(
+    #     "S y1, S y2", "S x", "x = x * y1 * y2", "_modulate_2d"  # overwrite x
+    # )

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -451,16 +451,18 @@ if CUPY_ENABLED:
     #  CUDA code for this and put inside RawKernel
     _modulate_2d = cp.ElementwiseKernel("S x, S y1, S y2", "S z", "z = x * y1 * y2", "_modulate_2d")
 
-    _real_interpolation_1d = cp.ElementwiseKernel(
-        "S x0_FS, S C",
-        "S x",
-        "x = (S) 2 * C * x + x0_FS",
-        "_real_interpolation_1d",
-    )
-
-    _real_interpolation_2d = cp.ElementwiseKernel(
-        "S x0_FS, S x_pp, S x_np",
-        "S z",
-        "z = (S) 2 * x_pp + (S) 2 *  x_np - x0_FS",
-        "_real_interpolation_2d",
-    )
+    _real_interpolation_1d = cp.fuse(_real_interpolation_1d)
+    _real_interpolation_2d = cp.fuse(_real_interpolation_2d)
+    # _real_interpolation_1d = cp.ElementwiseKernel(
+    #     "S x0_FS, S C",
+    #     "S x",
+    #     "x = (S) 2 * C * x + x0_FS",
+    #     "_real_interpolation_1d",
+    # )
+    #
+    # _real_interpolation_2d = cp.ElementwiseKernel(
+    #     "S x0_FS, S x_pp, S x_np",
+    #     "S z",
+    #     "z = (S) 2 * x_pp + (S) 2 *  x_np - x0_FS",
+    #     "_real_interpolation_2d",
+    # )

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -216,7 +216,7 @@ def _verify_ffsn_input(x, T, T_c, N_FS, axes):
         axes = list(range(D))
 
     xp = get_array_module(x)
-    N_s = xp.array(x.shape)[axes]
+    N_s = xp.array(x.shape, dtype=int)[axes]
 
     # check valid values
     for d in range(D):

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -215,8 +215,7 @@ def _verify_ffsn_input(x, T, T_c, N_FS, axes):
     else:
         axes = list(range(D))
 
-    xp = get_array_module(x)
-    N_s = xp.array(x.shape)[axes]
+    N_s = np.array(x.shape)[axes]
 
     # check valid values
     for d in range(D):

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -434,7 +434,5 @@ def _modulate_2d(x, y1, y2):
 if CUPY_ENABLED:
     import cupy as cp
 
-    _modulate_2d = cp.fuse(_modulate_2d)
-    # _modulate_2d = foo = cp.ElementwiseKernel(
-    #     "S y1, S y2", "S x", "x = x * y1 * y2", "_modulate_2d"  # overwrite x
-    # )
+    # _modulate_2d = cp.fuse(_modulate_2d)
+    _modulate_2d = cp.ElementwiseKernel("S x, S y1, S y2", "S z", "z = x * y1 * y2", "_modulate_2d")

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -426,7 +426,13 @@ def _create_modulation_vectors(N_s, N_FS, T, T_c):
     xp = get_backend()
     M = N_s // 2
     N = N_FS // 2
-    E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros(N_s - N_FS, dtype=xp.int)]
+
+    fs_idx = xp.arange(start=-N, stop=N + 1)
+    zero_pad = xp.zeros((N_s - N_FS,), dtype=xp.int)
+    E_1 = xp.concatenate((fs_idx, zero_pad))
+
+    # E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros(N_s - N_FS, dtype=xp.int)]
+
     B_2 = xp.exp(-1j * 2 * xp.pi / N_s)
 
     if N_s % 2 == 1:

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -367,11 +367,14 @@ def ffsn_sample(T, N_FS, T_c, N_s, mod=None):
     idx = []
     for d in range(D):
         # get values for d-dimension
-        _sample_points, _idx = ffs_sample(T=T[d], N_FS=N_FS[d], T_c=T_c[d], N_s=N_s[d], mod=mod)
+        # cast to int in case cupy array is passed
+        _sample_points, _idx = ffs_sample(
+            T=int(T[d]), N_FS=int(N_FS[d]), T_c=int(T_c[d]), N_s=int(N_s[d]), mod=mod
+        )
 
         # reshape for sparse array
         sh = [1] * D
-        sh[d] = N_s[d]
+        sh[d] = int(N_s[d])
         sample_points.append(_sample_points.reshape(sh))
         idx.append(_idx.reshape(sh))
 

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -434,5 +434,4 @@ def _modulate_2d(x, y1, y2):
 if CUPY_ENABLED:
     import cupy as cp
 
-    # _modulate_2d = cp.fuse(_modulate_2d)
     _modulate_2d = cp.ElementwiseKernel("S x, S y1, S y2", "S z", "z = x * y1 * y2", "_modulate_2d")

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -451,18 +451,18 @@ if CUPY_ENABLED:
     #  CUDA code for this and put inside RawKernel
     _modulate_2d = cp.ElementwiseKernel("S x, S y1, S y2", "S z", "z = x * y1 * y2", "_modulate_2d")
 
-    _real_interpolation_1d = cp.fuse(_real_interpolation_1d)
-    _real_interpolation_2d = cp.fuse(_real_interpolation_2d)
-    # _real_interpolation_1d = cp.ElementwiseKernel(
-    #     "S x0_FS, S C",
-    #     "S x",
-    #     "x = (S) 2 * C * x + x0_FS",
-    #     "_real_interpolation_1d",
-    # )
-    #
-    # _real_interpolation_2d = cp.ElementwiseKernel(
-    #     "S x0_FS, S x_pp, S x_np",
-    #     "S z",
-    #     "z = (S) 2 * x_pp + (S) 2 *  x_np - x0_FS",
-    #     "_real_interpolation_2d",
-    # )
+    # _real_interpolation_1d = cp.fuse(_real_interpolation_1d)
+    # _real_interpolation_2d = cp.fuse(_real_interpolation_2d)
+    _real_interpolation_1d = cp.ElementwiseKernel(
+        "S x0_FS, S C",
+        "S x",
+        "x = (S) 2 * C * x + x0_FS",
+        "_real_interpolation_1d",
+    )
+
+    _real_interpolation_2d = cp.ElementwiseKernel(
+        "S x0_FS, S x_pp, S x_np",
+        "S z",
+        "z = (S) 2 * x_pp + (S) 2 *  x_np - x0_FS",
+        "_real_interpolation_2d",
+    )

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -432,4 +432,6 @@ def _modulate_2d(x, y1, y2):
 
 
 if CUPY_ENABLED:
+    import cupy as cp
+
     _modulate = cp.fuse(_modulate_2d)

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -434,4 +434,7 @@ def _modulate_2d(x, y1, y2):
 if CUPY_ENABLED:
     import cupy as cp
 
-    _modulate = cp.fuse(_modulate_2d)
+    # _modulate_2d = cp.fuse(_modulate_2d)
+    _modulate_2d = foo = cp.ElementwiseKernel(
+        "S y1, S y2", "S x", "x = x * y1 * y2", "_modulate_2d"  # overwrite x
+    )

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -424,8 +424,10 @@ def _create_modulation_vectors(N_s, N_FS, T, T_c):
     :py:func:`~pyffs.ffs.ffsn`, :py:func:`~pyffs.ffs.iffsn`
     """
     xp = get_backend()
-    M = int(N_s // 2)
-    N = int(N_FS // 2)
+    N_s = int(N_s)
+    N_FS = int(N_FS)
+    M = N_s // 2
+    N = N_FS // 2
     E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros(N_s - N_FS, dtype=int)]
     B_2 = xp.exp(-1j * 2 * xp.pi / N_s)
 

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -424,7 +424,8 @@ def _create_modulation_vectors(N_s, N_FS, T, T_c):
     :py:func:`~pyffs.ffs.ffsn`, :py:func:`~pyffs.ffs.iffsn`
     """
     xp = get_backend()
-    M, N = xp.r_[N_s, N_FS] // 2
+    M = N_s // 2
+    N = N_FS // 2
     E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros((N_s - N_FS,), dtype=int)]
     B_2 = xp.exp(-1j * 2 * xp.pi / N_s)
 

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -428,7 +428,7 @@ def _create_modulation_vectors(N_s, N_FS, T, T_c):
     N = N_FS // 2
 
     fs_idx = xp.arange(start=-N, stop=N + 1)
-    zero_pad = xp.zeros((N_s - N_FS,), dtype=xp.int)
+    zero_pad = xp.zeros((int(N_s) - N_FS,), dtype=xp.int)
     E_1 = xp.concatenate((fs_idx, zero_pad))
 
     # E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros(N_s - N_FS, dtype=xp.int)]

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -12,7 +12,7 @@ Helper functions.
 
 import cmath
 
-from pyffs.backend import get_backend
+from pyffs.backend import get_backend, CUPY_ENABLED
 
 
 def _index(x, axis, index_spec):
@@ -425,3 +425,11 @@ def _create_modulation_vectors(N_s, N_FS, T, T_c, mod=None):
         E_2 = mod.r_[mod.arange(start=0, stop=M), mod.arange(start=-M, stop=0)]
 
     return B_1 ** E_1, B_2 ** (N * E_2)
+
+
+def _modulate_2d(x, y1, y2):
+    return x * y1 * y2
+
+
+if CUPY_ENABLED:
+    _modulate = cp.fuse(_modulate_2d)

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -447,22 +447,24 @@ def _real_interpolation_2d(x0_FS, x_pp, x_np):
 if CUPY_ENABLED:
     import cupy as cp
 
-    # TODO : could speed up by combining with computing modulation vectors would need to write
-    #  CUDA code for this and put inside RawKernel
-    _modulate_2d = cp.ElementwiseKernel("S x, S y1, S y2", "S z", "z = x * y1 * y2", "_modulate_2d")
+    _modulate_2d = cp.fuse(_modulate_2d)
+    _real_interpolation_1d = cp.fuse(_real_interpolation_1d)
+    _real_interpolation_2d = cp.fuse(_real_interpolation_2d)
 
-    # _real_interpolation_1d = cp.fuse(_real_interpolation_1d)
-    # _real_interpolation_2d = cp.fuse(_real_interpolation_2d)
-    _real_interpolation_1d = cp.ElementwiseKernel(
-        "S x0_FS, S C",
-        "S x",
-        "x = (S) 2 * C * x + x0_FS",
-        "_real_interpolation_1d",
-    )
-
-    _real_interpolation_2d = cp.ElementwiseKernel(
-        "S x0_FS, S x_pp, S x_np",
-        "S z",
-        "z = (S) 2 * x_pp + (S) 2 *  x_np - x0_FS",
-        "_real_interpolation_2d",
-    )
+    # TODO : could speed up by combining with computing modulation vectors which would require
+    #  writing CUDA code for this and put inside RawKernel. NB if not use using decorators, will
+    #  run into issue when numpy array is provided when CUPY_ENABLED = TRUE.
+    # _modulate_2d = cp.ElementwiseKernel("S x, S y1, S y2", "S z", "z = x * y1 * y2", "_modulate_2d")
+    # _real_interpolation_1d = cp.ElementwiseKernel(
+    #     "S x0_FS, S C",
+    #     "S x",
+    #     "x = (S) 2 * C * x + x0_FS",
+    #     "_real_interpolation_1d",
+    # )
+    #
+    # _real_interpolation_2d = cp.ElementwiseKernel(
+    #     "S x0_FS, S x_pp, S x_np",
+    #     "S z",
+    #     "z = (S) 2 * x_pp + (S) 2 *  x_np - x0_FS",
+    #     "_real_interpolation_2d",
+    # )

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -425,14 +425,14 @@ def _create_modulation_vectors(N_s, N_FS, T, T_c):
     """
     xp = get_backend()
     M, N = xp.r_[N_s, N_FS] // 2
-    E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), np.zeros((N_s - N_FS,), dtype=int)]
-    B_2 = xp.exp(-1j * 2 * np.pi / N_s)
+    E_1 = xp.r_[xp.arange(start=-N, stop=N + 1), xp.zeros((N_s - N_FS,), dtype=int)]
+    B_2 = xp.exp(-1j * 2 * xp.pi / N_s)
 
     if N_s % 2 == 1:
-        B_1 = xp.exp(1j * (2 * np.pi / T) * T_c)
+        B_1 = xp.exp(1j * (2 * xp.pi / T) * T_c)
         E_2 = xp.r_[xp.arange(start=0, stop=M + 1), xp.arange(start=-M, stop=0)]
     else:
-        B_1 = xp.exp(1j * (2 * np.pi / T) * (T_c + T / (2 * N_s)))
+        B_1 = xp.exp(1j * (2 * xp.pi / T) * (T_c + T / (2 * N_s)))
         E_2 = xp.r_[xp.arange(start=0, stop=M), xp.arange(start=-M, stop=0)]
 
     return B_1 ** E_1, B_2 ** (N * E_2)

--- a/pyffs/util.py
+++ b/pyffs/util.py
@@ -216,7 +216,7 @@ def _verify_ffsn_input(x, T, T_c, N_FS, axes):
         axes = list(range(D))
 
     xp = get_array_module(x)
-    N_s = xp.array(x.shape, dtype=int)[axes]
+    N_s = xp.array(x.shape)[axes]
 
     # check valid values
     for d in range(D):

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,4 +50,4 @@ dev =
     sphinx_rtd_theme == 0.4.*
     pytest >= 6.*
     click >= 7.*
-gpu = cupy >= 8.6
+cuda110 = cupy-cuda110 >= 8.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,9 @@
 # #############################################################################
 # setup.cfg
 # =========
-# Author : Sepand KASHANI [kashani.sepand@gmail.com]
+# Authors :
+# Sepand KASHANI [kashani.sepand@gmail.com]
+# Eric Bezzam [ebezzam@gmail.com]
 # #############################################################################
 
 [metadata]

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     numpy >= 1.10
-    scipy >= 1.0
+    scipy >= 1.5.0
 
 
 [options.extras_require]
@@ -50,3 +50,4 @@ dev =
     sphinx_rtd_theme == 0.4.*
     pytest >= 6.*
     click >= 7.*
+gpu = cupy >= 8.6

--- a/test/test_czt.py
+++ b/test/test_czt.py
@@ -6,7 +6,6 @@
 # Eric BEZZAM [ebezzam@gmail.com]
 # #############################################################################
 
-import numpy as np
 from pyffs import czt, cztn, _cztn
 from pyffs.backend import AVAILABLE_MOD
 
@@ -21,16 +20,16 @@ class TestCZT:
         for mod in AVAILABLE_MOD:
             x = mod.random.randn(N, 3) + 1j * mod.random.randn(N, 3)
             dft_x = mod.fft.fft(x, axis=0)
-            czt_x = czt(x, A=1, W=np.exp(-1j * 2 * mod.pi / N), M=M, axis=0)
-            assert np.allclose(dft_x, czt_x)
+            czt_x = czt(x, A=1, W=mod.exp(-1j * 2 * mod.pi / N), M=M, axis=0)
+            assert mod.allclose(dft_x, czt_x)
 
     def test_czt_idft(self):
         N = M = 10
         for mod in AVAILABLE_MOD:
             x = mod.random.randn(N) + 1j * mod.random.randn(N)
             idft_x = mod.fft.ifft(x)
-            czt_x = czt(x, A=1, W=mod.exp(1j * 2 * np.pi / N), M=M)
-            assert np.allclose(idft_x, czt_x / N)  # czt() does not do the scaling.
+            czt_x = czt(x, A=1, W=mod.exp(1j * 2 * mod.pi / N), M=M)
+            assert mod.allclose(idft_x, czt_x / N)  # czt() does not do the scaling.
 
     def test_cztn(self):
         N = M = 10
@@ -39,7 +38,7 @@ class TestCZT:
             x = mod.random.randn(N, N, N) + 1j * mod.random.randn(N, N, N)  # extra dimension
             dft_x = mod.fft.fftn(x, axes=(1, 2))
             czt_x = cztn(x, A=[1, 1], W=[W, W], M=[M, M], axes=(1, 2))
-            assert np.allclose(dft_x, czt_x)
+            assert mod.allclose(dft_x, czt_x)
 
     def test_cztn_ref(self):
         N = M = 10
@@ -48,4 +47,4 @@ class TestCZT:
             x = mod.random.randn(N, N) + 1j * mod.random.randn(N, N)
             dft_x = mod.fft.fft2(x)
             czt_x = _cztn(x, A=[1, 1], W=[W, W], M=[M, M])
-            assert np.allclose(dft_x, czt_x)
+            assert mod.allclose(dft_x, czt_x)

--- a/test/test_czt.py
+++ b/test/test_czt.py
@@ -8,6 +8,7 @@
 
 import numpy as np
 from pyffs import czt, cztn, _cztn
+from pyffs.backend import AVAILABLE_MOD
 
 
 class TestCZT:
@@ -17,30 +18,34 @@ class TestCZT:
 
     def test_czt_dft(self):
         N = M = 10
-        x = np.random.randn(N, 3) + 1j * np.random.randn(N, 3)
-        dft_x = np.fft.fft(x, axis=0)
-        czt_x = czt(x, A=1, W=np.exp(-1j * 2 * np.pi / N), M=M, axis=0)
-        assert np.allclose(dft_x, czt_x)
+        for mod in AVAILABLE_MOD:
+            x = mod.random.randn(N, 3) + 1j * mod.random.randn(N, 3)
+            dft_x = mod.fft.fft(x, axis=0)
+            czt_x = czt(x, A=1, W=np.exp(-1j * 2 * mod.pi / N), M=M, axis=0)
+            assert np.allclose(dft_x, czt_x)
 
     def test_czt_idft(self):
         N = M = 10
-        x = np.random.randn(N) + 1j * np.random.randn(N)
-        idft_x = np.fft.ifft(x)
-        czt_x = czt(x, A=1, W=np.exp(1j * 2 * np.pi / N), M=M)
-        assert np.allclose(idft_x, czt_x / N)  # czt() does not do the scaling.
+        for mod in AVAILABLE_MOD:
+            x = mod.random.randn(N) + 1j * mod.random.randn(N)
+            idft_x = mod.fft.ifft(x)
+            czt_x = czt(x, A=1, W=mod.exp(1j * 2 * np.pi / N), M=M)
+            assert np.allclose(idft_x, czt_x / N)  # czt() does not do the scaling.
 
     def test_cztn(self):
         N = M = 10
-        W = np.exp(-1j * 2 * np.pi / N)
-        x = np.random.randn(N, N, N) + 1j * np.random.randn(N, N, N)  # extra dimension
-        dft_x = np.fft.fftn(x, axes=(1, 2))
-        czt_x = cztn(x, A=[1, 1], W=[W, W], M=[M, M], axes=(1, 2))
-        assert np.allclose(dft_x, czt_x)
+        for mod in AVAILABLE_MOD:
+            W = mod.exp(-1j * 2 * mod.pi / N)
+            x = mod.random.randn(N, N, N) + 1j * mod.random.randn(N, N, N)  # extra dimension
+            dft_x = mod.fft.fftn(x, axes=(1, 2))
+            czt_x = cztn(x, A=[1, 1], W=[W, W], M=[M, M], axes=(1, 2))
+            assert np.allclose(dft_x, czt_x)
 
     def test_cztn_ref(self):
         N = M = 10
-        W = np.exp(-1j * 2 * np.pi / N)
-        x = np.random.randn(N, N) + 1j * np.random.randn(N, N)
-        dft_x = np.fft.fft2(x)
-        czt_x = _cztn(x, A=[1, 1], W=[W, W], M=[M, M])
-        assert np.allclose(dft_x, czt_x)
+        for mod in AVAILABLE_MOD:
+            W = mod.exp(-1j * 2 * mod.pi / N)
+            x = mod.random.randn(N, N) + 1j * mod.random.randn(N, N)
+            dft_x = mod.fft.fft2(x)
+            czt_x = _cztn(x, A=[1, 1], W=[W, W], M=[M, M])
+            assert np.allclose(dft_x, czt_x)

--- a/test/test_ffs.py
+++ b/test/test_ffs.py
@@ -7,9 +7,6 @@
 # #############################################################################
 
 import math
-
-import numpy as np
-
 from pyffs import (
     ffs,
     ffs_sample,
@@ -41,13 +38,13 @@ class TestFFS:
             diric_FS = ffs(diric_samples, T, T_c, N_FS)
 
             # Compare with theoretical result.
-            assert np.allclose(diric_FS[:N_FS], dirichlet_fs(N_FS, T, T_c))
+            assert mod.allclose(diric_FS[:N_FS], dirichlet_fs(N_FS, T, T_c))
 
             # Inverse transform.
             diric_samples_recov = iffs(diric_FS, T, T_c, N_FS)
 
             # Compare with original samples.
-            assert np.allclose(diric_samples, diric_samples_recov)
+            assert mod.allclose(diric_samples, diric_samples_recov)
 
     def test_ffsn_axes(self):
         T_x = T_y = 1
@@ -66,7 +63,7 @@ class TestFFS:
             )
 
             # Add new dimension.
-            diric_samples = diric_samples[:, np.newaxis, :]
+            diric_samples = diric_samples[:, mod.newaxis, :]
             axes = (0, 2)
 
             # Perform transform.
@@ -75,10 +72,10 @@ class TestFFS:
             )
 
             # Compare with theoretical result.
-            diric_FS_exact = np.outer(
-                dirichlet_fs(N_FSx, T_x, T_cx), dirichlet_fs(N_FSy, T_y, T_cy)
+            diric_FS_exact = mod.outer(
+                dirichlet_fs(N_FSx, T_x, T_cx, mod=mod), dirichlet_fs(N_FSy, T_y, T_cy, mod=mod)
             )
-            assert np.allclose(diric_FS[:N_FSx, 0, :N_FSy], diric_FS_exact)
+            assert mod.allclose(diric_FS[:N_FSx, 0, :N_FSy], diric_FS_exact)
 
             # Inverse transform.
             diric_samples_recov = iffsn(
@@ -86,7 +83,7 @@ class TestFFS:
             )
 
             # Compare with original samples.
-            assert np.allclose(diric_samples, diric_samples_recov)
+            assert mod.allclose(diric_samples, diric_samples_recov)
 
     def test_ffsn_ref(self):
         T = [1, 1]
@@ -102,16 +99,17 @@ class TestFFS:
             diric_FS = _ffsn(x=diric_samples, T=T, N_FS=N_FS, T_c=T_c)
 
             # Compare with theoretical result.
-            diric_FS_exact = np.outer(
-                dirichlet_fs(N_FS[0], T[0], T_c[0]), dirichlet_fs(N_FS[1], T[1], T_c[1])
+            diric_FS_exact = mod.outer(
+                dirichlet_fs(N_FS[0], T[0], T_c[0], mod=mod),
+                dirichlet_fs(N_FS[1], T[1], T_c[1], mod=mod),
             )
-            assert np.allclose(diric_FS[: N_FS[0], : N_FS[1]], diric_FS_exact)
+            assert mod.allclose(diric_FS[: N_FS[0], : N_FS[1]], diric_FS_exact)
 
             # Inverse transform.
             diric_samples_recov = _iffsn(x_FS=diric_FS, T=T, T_c=T_c, N_FS=N_FS)
 
             # Compare with original samples.
-            assert np.allclose(diric_samples, diric_samples_recov)
+            assert mod.allclose(diric_samples, diric_samples_recov)
 
     def test_ffsn(self):
         T = [1, 1]
@@ -127,13 +125,14 @@ class TestFFS:
             diric_FS = ffsn(x=diric_samples, T=T, N_FS=N_FS, T_c=T_c)
 
             # Compare with theoretical result.
-            diric_FS_exact = np.outer(
-                dirichlet_fs(N_FS[0], T[0], T_c[0]), dirichlet_fs(N_FS[1], T[1], T_c[1])
+            diric_FS_exact = mod.outer(
+                dirichlet_fs(N_FS[0], T[0], T_c[0], mod=mod),
+                dirichlet_fs(N_FS[1], T[1], T_c[1], mod=mod),
             )
-            assert np.allclose(diric_FS[: N_FS[0], : N_FS[1]], diric_FS_exact)
+            assert mod.allclose(diric_FS[: N_FS[0], : N_FS[1]], diric_FS_exact)
 
             # Inverse transform.
             diric_samples_recov = iffsn(x_FS=diric_FS, T=T, T_c=T_c, N_FS=N_FS)
 
             # Compare with original samples.
-            assert np.allclose(diric_samples, diric_samples_recov)
+            assert mod.allclose(diric_samples, diric_samples_recov)

--- a/test/test_ffs.py
+++ b/test/test_ffs.py
@@ -21,6 +21,7 @@ from pyffs import (
     _iffsn,
 )
 from pyffs.func import dirichlet, dirichlet_fs, dirichlet_2D
+from pyffs.backend import AVAILABLE_MOD
 
 
 class TestFFS:
@@ -32,19 +33,21 @@ class TestFFS:
         T, T_c, N_FS = math.pi, math.e, 15
         N_samples = 16  # Any >= N_FS will do, but highly-composite best.
 
-        # Sample the kernel and do the transform.
-        sample_points, _ = ffs_sample(T, N_FS, T_c, N_samples)
-        diric_samples = dirichlet(sample_points, T, T_c, N_FS)
-        diric_FS = ffs(diric_samples, T, T_c, N_FS)
+        for mod in AVAILABLE_MOD:
 
-        # Compare with theoretical result.
-        assert np.allclose(diric_FS[:N_FS], dirichlet_fs(N_FS, T, T_c))
+            # Sample the kernel and do the transform.
+            sample_points, _ = ffs_sample(T, N_FS, T_c, N_samples, mod=mod)
+            diric_samples = dirichlet(sample_points, T, T_c, N_FS)
+            diric_FS = ffs(diric_samples, T, T_c, N_FS)
 
-        # Inverse transform.
-        diric_samples_recov = iffs(diric_FS, T, T_c, N_FS)
+            # Compare with theoretical result.
+            assert np.allclose(diric_FS[:N_FS], dirichlet_fs(N_FS, T, T_c))
 
-        # Compare with original samples.
-        assert np.allclose(diric_samples, diric_samples_recov)
+            # Inverse transform.
+            diric_samples_recov = iffs(diric_FS, T, T_c, N_FS)
+
+            # Compare with original samples.
+            assert np.allclose(diric_samples, diric_samples_recov)
 
     def test_ffsn_axes(self):
         T_x = T_y = 1
@@ -52,34 +55,38 @@ class TestFFS:
         N_FSx = N_FSy = 3
         N_sx, N_sy = 4, 3
 
-        # Sample the kernel.
-        sample_points, _ = ffsn_sample(
-            T=[T_x, T_y], N_FS=[N_FSx, N_FSy], T_c=[T_cx, T_cy], N_s=[N_sx, N_sy]
-        )
-        diric_samples = dirichlet_2D(
-            sample_points=sample_points, T=[T_x, T_y], T_c=[T_cx, T_cy], N_FS=[N_FSx, N_FSy]
-        )
+        for mod in AVAILABLE_MOD:
 
-        # Add new dimension.
-        diric_samples = diric_samples[:, np.newaxis, :]
-        axes = (0, 2)
+            # Sample the kernel.
+            sample_points, _ = ffsn_sample(
+                T=[T_x, T_y], N_FS=[N_FSx, N_FSy], T_c=[T_cx, T_cy], N_s=[N_sx, N_sy], mod=mod
+            )
+            diric_samples = dirichlet_2D(
+                sample_points=sample_points, T=[T_x, T_y], T_c=[T_cx, T_cy], N_FS=[N_FSx, N_FSy]
+            )
 
-        # Perform transform.
-        diric_FS = ffsn(
-            x=diric_samples, T=[T_x, T_y], T_c=[T_cx, T_cy], N_FS=[N_FSx, N_FSy], axes=axes
-        )
+            # Add new dimension.
+            diric_samples = diric_samples[:, np.newaxis, :]
+            axes = (0, 2)
 
-        # Compare with theoretical result.
-        diric_FS_exact = np.outer(dirichlet_fs(N_FSx, T_x, T_cx), dirichlet_fs(N_FSy, T_y, T_cy))
-        assert np.allclose(diric_FS[:N_FSx, 0, :N_FSy], diric_FS_exact)
+            # Perform transform.
+            diric_FS = ffsn(
+                x=diric_samples, T=[T_x, T_y], T_c=[T_cx, T_cy], N_FS=[N_FSx, N_FSy], axes=axes
+            )
 
-        # Inverse transform.
-        diric_samples_recov = iffsn(
-            x_FS=diric_FS, T=[T_x, T_y], T_c=[T_cx, T_cy], N_FS=[N_FSx, N_FSy], axes=axes
-        )
+            # Compare with theoretical result.
+            diric_FS_exact = np.outer(
+                dirichlet_fs(N_FSx, T_x, T_cx), dirichlet_fs(N_FSy, T_y, T_cy)
+            )
+            assert np.allclose(diric_FS[:N_FSx, 0, :N_FSy], diric_FS_exact)
 
-        # Compare with original samples.
-        assert np.allclose(diric_samples, diric_samples_recov)
+            # Inverse transform.
+            diric_samples_recov = iffsn(
+                x_FS=diric_FS, T=[T_x, T_y], T_c=[T_cx, T_cy], N_FS=[N_FSx, N_FSy], axes=axes
+            )
+
+            # Compare with original samples.
+            assert np.allclose(diric_samples, diric_samples_recov)
 
     def test_ffsn_ref(self):
         T = [1, 1]
@@ -87,22 +94,24 @@ class TestFFS:
         N_FS = [3, 3]
         N_s = [4, 3]
 
-        # Sample the kernel and do the transform.
-        sample_points, _ = ffsn_sample(T=T, N_FS=N_FS, T_c=T_c, N_s=N_s)
-        diric_samples = dirichlet_2D(sample_points=sample_points, T=T, T_c=T_c, N_FS=N_FS)
-        diric_FS = _ffsn(x=diric_samples, T=T, N_FS=N_FS, T_c=T_c)
+        for mod in AVAILABLE_MOD:
 
-        # Compare with theoretical result.
-        diric_FS_exact = np.outer(
-            dirichlet_fs(N_FS[0], T[0], T_c[0]), dirichlet_fs(N_FS[1], T[1], T_c[1])
-        )
-        assert np.allclose(diric_FS[: N_FS[0], : N_FS[1]], diric_FS_exact)
+            # Sample the kernel and do the transform.
+            sample_points, _ = ffsn_sample(T=T, N_FS=N_FS, T_c=T_c, N_s=N_s, mod=mod)
+            diric_samples = dirichlet_2D(sample_points=sample_points, T=T, T_c=T_c, N_FS=N_FS)
+            diric_FS = _ffsn(x=diric_samples, T=T, N_FS=N_FS, T_c=T_c)
 
-        # Inverse transform.
-        diric_samples_recov = _iffsn(x_FS=diric_FS, T=T, T_c=T_c, N_FS=N_FS)
+            # Compare with theoretical result.
+            diric_FS_exact = np.outer(
+                dirichlet_fs(N_FS[0], T[0], T_c[0]), dirichlet_fs(N_FS[1], T[1], T_c[1])
+            )
+            assert np.allclose(diric_FS[: N_FS[0], : N_FS[1]], diric_FS_exact)
 
-        # Compare with original samples.
-        assert np.allclose(diric_samples, diric_samples_recov)
+            # Inverse transform.
+            diric_samples_recov = _iffsn(x_FS=diric_FS, T=T, T_c=T_c, N_FS=N_FS)
+
+            # Compare with original samples.
+            assert np.allclose(diric_samples, diric_samples_recov)
 
     def test_ffsn(self):
         T = [1, 1]
@@ -110,19 +119,21 @@ class TestFFS:
         N_FS = [3, 3]
         N_s = [4, 3]
 
-        # Sample the kernel and do the transform.
-        sample_points, _ = ffsn_sample(T=T, N_FS=N_FS, T_c=T_c, N_s=N_s)
-        diric_samples = dirichlet_2D(sample_points=sample_points, T=T, T_c=T_c, N_FS=N_FS)
-        diric_FS = ffsn(x=diric_samples, T=T, N_FS=N_FS, T_c=T_c)
+        for mod in AVAILABLE_MOD:
 
-        # Compare with theoretical result.
-        diric_FS_exact = np.outer(
-            dirichlet_fs(N_FS[0], T[0], T_c[0]), dirichlet_fs(N_FS[1], T[1], T_c[1])
-        )
-        assert np.allclose(diric_FS[: N_FS[0], : N_FS[1]], diric_FS_exact)
+            # Sample the kernel and do the transform.
+            sample_points, _ = ffsn_sample(T=T, N_FS=N_FS, T_c=T_c, N_s=N_s, mod=mod)
+            diric_samples = dirichlet_2D(sample_points=sample_points, T=T, T_c=T_c, N_FS=N_FS)
+            diric_FS = ffsn(x=diric_samples, T=T, N_FS=N_FS, T_c=T_c)
 
-        # Inverse transform.
-        diric_samples_recov = iffsn(x_FS=diric_FS, T=T, T_c=T_c, N_FS=N_FS)
+            # Compare with theoretical result.
+            diric_FS_exact = np.outer(
+                dirichlet_fs(N_FS[0], T[0], T_c[0]), dirichlet_fs(N_FS[1], T[1], T_c[1])
+            )
+            assert np.allclose(diric_FS[: N_FS[0], : N_FS[1]], diric_FS_exact)
 
-        # Compare with original samples.
-        assert np.allclose(diric_samples, diric_samples_recov)
+            # Inverse transform.
+            diric_samples_recov = iffsn(x_FS=diric_FS, T=T, T_c=T_c, N_FS=N_FS)
+
+            # Compare with original samples.
+            assert np.allclose(diric_samples, diric_samples_recov)

--- a/test/test_interp.py
+++ b/test/test_interp.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from pyffs.func import dirichlet, dirichlet_fs, dirichlet_2D
 from pyffs.interp import fs_interp, fs_interpn
+from pyffs.backend import AVAILABLE_MOD
 
 
 class TestInterp:
@@ -23,22 +24,24 @@ class TestInterp:
         # parameters of signal
         T, T_c, N_FS = math.pi, math.e, 15
 
-        # And the kernel's FS coefficients.
-        diric_FS = dirichlet_fs(N_FS, T, T_c)
+        for mod in AVAILABLE_MOD:
 
-        # Generate interpolated signal
-        a, b = T_c + (T / 2) * np.r_[-1, 1]
-        M = 100  # We want lots of points.
-        diric_sig = fs_interp(diric_FS, T, a, b, M)
+            # And the kernel's FS coefficients.
+            diric_FS = dirichlet_fs(N_FS, T, T_c, mod=mod)
 
-        # Compare with theoretical result.
-        t = a + (b - a) / (M - 1) * np.arange(M)
-        diric_sig_exact = dirichlet(t, T, T_c, N_FS)
-        assert np.allclose(diric_sig, diric_sig_exact)
+            # Generate interpolated signal
+            a, b = T_c + (T / 2) * np.r_[-1, 1]
+            M = 100  # We want lots of points.
+            diric_sig = fs_interp(diric_FS, T, a, b, M)
 
-        # Try real version
-        diric_sig_real = fs_interp(diric_FS, T, a, b, M, real_x=True)
-        assert np.allclose(diric_sig, diric_sig_real)
+            # Compare with theoretical result.
+            t = a + (b - a) / (M - 1) * np.arange(M)
+            diric_sig_exact = dirichlet(t, T, T_c, N_FS)
+            assert np.allclose(diric_sig, diric_sig_exact)
+
+            # Try real version
+            diric_sig_real = fs_interp(diric_FS, T, a, b, M, real_x=True)
+            assert np.allclose(diric_sig, diric_sig_real)
 
     def test_fs_interp2(self):
         # parameters of signal
@@ -46,26 +49,30 @@ class TestInterp:
         N_FSx = N_FSy = 5
         T_cx = T_cy = math.e
 
-        # And the kernel's FS coefficients.
-        diric_FS = np.outer(dirichlet_fs(N_FSx, T_x, T_cx), dirichlet_fs(N_FSy, T_y, T_cy))
+        for mod in AVAILABLE_MOD:
 
-        # Generate interpolated signal
-        a_x, b_x = T_cx + (T_x / 2) * np.r_[-1, 1]
-        a_y, b_y = T_cy + (T_y / 2) * np.r_[-1, 1]
-        M_x = M_y = 6
-        diric_sig = fs_interpn(diric_FS, T=[T_x, T_y], a=[a_x, a_y], b=[b_x, b_y], M=[M_x, M_y])
+            # And the kernel's FS coefficients.
+            diric_FS = mod.outer(
+                dirichlet_fs(N_FSx, T_x, T_cx, mod=mod), dirichlet_fs(N_FSy, T_y, T_cy, mod=mod)
+            )
 
-        # Compare with theoretical result.
-        sample_points_x = a_x + (b_x - a_x) / (M_x - 1) * np.arange(M_x)
-        sample_points_y = a_y + (b_y - a_y) / (M_y - 1) * np.arange(M_y)
-        sample_points = [sample_points_x.reshape(M_x, 1), sample_points_y.reshape(1, M_y)]
-        diric_sig_exact = dirichlet_2D(
-            sample_points, T=[T_x, T_y], T_c=[T_cx, T_cy], N_FS=[N_FSx, N_FSy]
-        )
-        assert np.allclose(diric_sig, diric_sig_exact)
+            # Generate interpolated signal
+            a_x, b_x = T_cx + (T_x / 2) * np.r_[-1, 1]
+            a_y, b_y = T_cy + (T_y / 2) * np.r_[-1, 1]
+            M_x = M_y = 6
+            diric_sig = fs_interpn(diric_FS, T=[T_x, T_y], a=[a_x, a_y], b=[b_x, b_y], M=[M_x, M_y])
 
-        # Try real version
-        diric_sig_real = fs_interpn(
-            diric_FS, T=[T_x, T_y], a=[a_x, a_y], b=[b_x, b_y], M=[M_x, M_y], real_x=True
-        )
-        assert np.allclose(diric_sig, diric_sig_real)
+            # Compare with theoretical result.
+            sample_points_x = a_x + (b_x - a_x) / (M_x - 1) * mod.arange(M_x)
+            sample_points_y = a_y + (b_y - a_y) / (M_y - 1) * mod.arange(M_y)
+            sample_points = [sample_points_x.reshape(M_x, 1), sample_points_y.reshape(1, M_y)]
+            diric_sig_exact = dirichlet_2D(
+                sample_points, T=[T_x, T_y], T_c=[T_cx, T_cy], N_FS=[N_FSx, N_FSy]
+            )
+            assert np.allclose(diric_sig, diric_sig_exact)
+
+            # Try real version
+            diric_sig_real = fs_interpn(
+                diric_FS, T=[T_x, T_y], a=[a_x, a_y], b=[b_x, b_y], M=[M_x, M_y], real_x=True
+            )
+            assert np.allclose(diric_sig, diric_sig_real)

--- a/test/test_interp.py
+++ b/test/test_interp.py
@@ -7,9 +7,6 @@
 # #############################################################################
 
 import math
-
-import numpy as np
-
 from pyffs.func import dirichlet, dirichlet_fs, dirichlet_2D
 from pyffs.interp import fs_interp, fs_interpn
 from pyffs.backend import AVAILABLE_MOD
@@ -30,26 +27,25 @@ class TestInterp:
             diric_FS = dirichlet_fs(N_FS, T, T_c, mod=mod)
 
             # Generate interpolated signal
-            a, b = T_c + (T / 2) * np.r_[-1, 1]
+            a, b = T_c + (T / 2) * mod.r_[-1, 1]
             M = 100  # We want lots of points.
             diric_sig = fs_interp(diric_FS, T, a, b, M)
 
             # Compare with theoretical result.
-            t = a + (b - a) / (M - 1) * np.arange(M)
+            t = a + (b - a) / (M - 1) * mod.arange(M)
             diric_sig_exact = dirichlet(t, T, T_c, N_FS)
-            assert np.allclose(diric_sig, diric_sig_exact)
+            assert mod.allclose(diric_sig, diric_sig_exact)
 
             # Try real version
             diric_sig_real = fs_interp(diric_FS, T, a, b, M, real_x=True)
-            assert np.allclose(diric_sig, diric_sig_real)
+            assert mod.allclose(diric_sig, diric_sig_real)
 
     def test_fs_interp2(self):
-        # parameters of signal
-        T_x = T_y = np.pi
-        N_FSx = N_FSy = 5
-        T_cx = T_cy = math.e
-
         for mod in AVAILABLE_MOD:
+            # parameters of signal
+            T_x = T_y = mod.pi
+            N_FSx = N_FSy = 5
+            T_cx = T_cy = math.e
 
             # And the kernel's FS coefficients.
             diric_FS = mod.outer(
@@ -57,8 +53,8 @@ class TestInterp:
             )
 
             # Generate interpolated signal
-            a_x, b_x = T_cx + (T_x / 2) * np.r_[-1, 1]
-            a_y, b_y = T_cy + (T_y / 2) * np.r_[-1, 1]
+            a_x, b_x = T_cx + (T_x / 2) * mod.r_[-1, 1]
+            a_y, b_y = T_cy + (T_y / 2) * mod.r_[-1, 1]
             M_x = M_y = 6
             diric_sig = fs_interpn(diric_FS, T=[T_x, T_y], a=[a_x, a_y], b=[b_x, b_y], M=[M_x, M_y])
 
@@ -69,10 +65,10 @@ class TestInterp:
             diric_sig_exact = dirichlet_2D(
                 sample_points, T=[T_x, T_y], T_c=[T_cx, T_cy], N_FS=[N_FSx, N_FSy]
             )
-            assert np.allclose(diric_sig, diric_sig_exact)
+            assert mod.allclose(diric_sig, diric_sig_exact)
 
             # Try real version
             diric_sig_real = fs_interpn(
                 diric_FS, T=[T_x, T_y], a=[a_x, a_y], b=[b_x, b_y], M=[M_x, M_y], real_x=True
             )
-            assert np.allclose(diric_sig, diric_sig_real)
+            assert mod.allclose(diric_sig, diric_sig_real)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -10,6 +10,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from pyffs import ffs_sample, ffsn_sample
+from pyffs.backend import AVAILABLE_MOD, get_array_module
 
 
 class TestUtil:
@@ -18,31 +19,38 @@ class TestUtil:
     """
 
     def test_ffs_sample(self):
-        sample_points, idx = ffs_sample(T=1, N_FS=5, T_c=np.pi, N_s=8)
-        assert_array_equal(
-            np.around(sample_points, 2),
-            np.array([3.2, 3.33, 3.45, 3.58, 2.7, 2.83, 2.95, 3.08]),
-        )
-        assert_array_equal(
-            idx,
-            np.array([4, 5, 6, 7, 0, 1, 2, 3]),
-        )
+        for mod in AVAILABLE_MOD:
+            sample_points, idx = ffs_sample(T=1, N_FS=5, T_c=np.pi, N_s=8, mod=mod)
+            assert_array_equal(
+                mod.around(sample_points, 2),
+                mod.array([3.2, 3.33, 3.45, 3.58, 2.7, 2.83, 2.95, 3.08]),
+            )
+            assert_array_equal(
+                idx,
+                mod.array([4, 5, 6, 7, 0, 1, 2, 3]),
+            )
+            assert get_array_module(sample_points) == mod
+            assert get_array_module(idx) == mod
 
     def test_ffsn_sample(self):
         N_s = [4, 3]
-        sample_points, idx = ffsn_sample(T=[1, 1], N_FS=[3, 3], T_c=[0, 0], N_s=N_s)
+        for mod in AVAILABLE_MOD:
+            sample_points, idx = ffsn_sample(T=[1, 1], N_FS=[3, 3], T_c=[0, 0], N_s=N_s, mod=mod)
 
-        # check sample points
-        assert sample_points[0].shape == (N_s[0], 1)
-        assert sample_points[1].shape == (1, N_s[1])
-        assert_array_equal(sample_points[0][:, 0], np.array([0.125, 0.375, -0.375, -0.125]))
-        assert_array_equal(sample_points[1][0, :], np.array([0, 1 / 3, -1 / 3]))
+            # check sample points
+            assert sample_points[0].shape == (N_s[0], 1)
+            assert sample_points[1].shape == (1, N_s[1])
+            assert_array_equal(sample_points[0][:, 0], mod.array([0.125, 0.375, -0.375, -0.125]))
+            assert_array_equal(sample_points[1][0, :], mod.array([0, 1 / 3, -1 / 3]))
 
-        # check index values
-        assert idx[0].shape == (N_s[0], 1)
-        assert idx[1].shape == (1, N_s[1])
-        assert_array_equal(idx[0][:, 0], np.array([2, 3, 0, 1]))
-        assert_array_equal(idx[1][0, :], np.array([1, 2, 0]))
+            # check index values
+            assert idx[0].shape == (N_s[0], 1)
+            assert idx[1].shape == (1, N_s[1])
+            assert_array_equal(idx[0][:, 0], mod.array([2, 3, 0, 1]))
+            assert_array_equal(idx[1][0, :], mod.array([1, 2, 0]))
+
+            assert get_array_module(sample_points) == mod
+            assert get_array_module(idx) == mod
 
     def test_ffsn_sample_shape(self):
         D = 5
@@ -51,11 +59,16 @@ class TestUtil:
         T_c = np.zeros(D)
         N_s = N_FS
 
-        sample_points, idx = ffsn_sample(T=T, N_FS=N_FS, T_c=T_c, N_s=N_s)
+        for mod in AVAILABLE_MOD:
 
-        # check shape
-        for d in range(D):
-            sh = [1] * D
-            sh[d] = N_s[d]
-            assert list(sample_points[d].shape) == sh
-            assert list(idx[d].shape) == sh
+            sample_points, idx = ffsn_sample(T=T, N_FS=N_FS, T_c=T_c, N_s=N_s, mod=mod)
+
+            # check shape
+            for d in range(D):
+                sh = [1] * D
+                sh[d] = N_s[d]
+                assert list(sample_points[d].shape) == sh
+                assert list(idx[d].shape) == sh
+
+            assert get_array_module(sample_points) == mod
+            assert get_array_module(idx) == mod

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -6,9 +6,6 @@
 # Eric BEZZAM [ebezzam@gmail.com]
 # #############################################################################
 
-import numpy as np
-from numpy.testing import assert_array_equal
-
 from pyffs import ffs_sample, ffsn_sample
 from pyffs.backend import AVAILABLE_MOD, get_array_module
 
@@ -20,12 +17,12 @@ class TestUtil:
 
     def test_ffs_sample(self):
         for mod in AVAILABLE_MOD:
-            sample_points, idx = ffs_sample(T=1, N_FS=5, T_c=np.pi, N_s=8, mod=mod)
-            assert_array_equal(
+            sample_points, idx = ffs_sample(T=1, N_FS=5, T_c=mod.pi, N_s=8, mod=mod)
+            mod.testing.assert_array_equal(
                 mod.around(sample_points, 2),
                 mod.array([3.2, 3.33, 3.45, 3.58, 2.7, 2.83, 2.95, 3.08]),
             )
-            assert_array_equal(
+            mod.testing.assert_array_equal(
                 idx,
                 mod.array([4, 5, 6, 7, 0, 1, 2, 3]),
             )
@@ -40,26 +37,27 @@ class TestUtil:
             # check sample points
             assert sample_points[0].shape == (N_s[0], 1)
             assert sample_points[1].shape == (1, N_s[1])
-            assert_array_equal(sample_points[0][:, 0], mod.array([0.125, 0.375, -0.375, -0.125]))
-            assert_array_equal(sample_points[1][0, :], mod.array([0, 1 / 3, -1 / 3]))
+            mod.testing.assert_array_equal(
+                sample_points[0][:, 0], mod.array([0.125, 0.375, -0.375, -0.125])
+            )
+            mod.testing.assert_array_equal(sample_points[1][0, :], mod.array([0, 1 / 3, -1 / 3]))
 
             # check index values
             assert idx[0].shape == (N_s[0], 1)
             assert idx[1].shape == (1, N_s[1])
-            assert_array_equal(idx[0][:, 0], mod.array([2, 3, 0, 1]))
-            assert_array_equal(idx[1][0, :], mod.array([1, 2, 0]))
+            mod.testing.assert_array_equal(idx[0][:, 0], mod.array([2, 3, 0, 1]))
+            mod.testing.assert_array_equal(idx[1][0, :], mod.array([1, 2, 0]))
 
-            assert get_array_module(sample_points) == mod
-            assert get_array_module(idx) == mod
+            assert all([get_array_module(s) == mod for s in sample_points])
+            assert all([get_array_module(i) == mod for i in idx])
 
     def test_ffsn_sample_shape(self):
-        D = 5
-        T = np.ones(D)
-        N_FS = np.arange(D) * 2 + 3
-        T_c = np.zeros(D)
-        N_s = N_FS
-
         for mod in AVAILABLE_MOD:
+            D = 5
+            T = mod.ones(D)
+            N_FS = mod.arange(D) * 2 + 3
+            T_c = mod.zeros(D)
+            N_s = N_FS
 
             sample_points, idx = ffsn_sample(T=T, N_FS=N_FS, T_c=T_c, N_s=N_s, mod=mod)
 
@@ -70,5 +68,5 @@ class TestUtil:
                 assert list(sample_points[d].shape) == sh
                 assert list(idx[d].shape) == sh
 
-            assert get_array_module(sample_points) == mod
-            assert get_array_module(idx) == mod
+            assert all([get_array_module(s) == mod for s in sample_points])
+            assert all([get_array_module(i) == mod for i in idx])


### PR DESCRIPTION
# Summary

- Sorry for a lot of commits... it's because I'm going between my local machine and Google Colab in order to test the changes.
- Below are some results comparing `numpy` and `cupy`.
- Using `cupy` / GPU has clear benefits as the dimension increases 🙂 
- I tried some advanced features (defining custom kernels) with no clear benefits.

# Initial benchmark results

- For interpolation tests, `naive` corresponds to direct-use of synthesis function for each time stamp.

### 2D FS computation (10 trials) 👍 

<img width="1047" alt="ffs2_google_colab_16apr2021" src="https://user-images.githubusercontent.com/4757445/115262145-8e239500-a134-11eb-8326-6683622bebb2.png">


### Interpolating 1D function with FS coefficients 👍 

<img width="1042" alt="Screen Shot 2021-04-19 at 14 30 23" src="https://user-images.githubusercontent.com/4757445/115260195-d3df5e00-a132-11eb-8801-d05c86be59b8.png">

### Interpolating 2D function with FS coefficients 👍 

<img width="1041" alt="Screen Shot 2021-04-19 at 14 36 21" src="https://user-images.githubusercontent.com/4757445/115261621-0e95c600-a134-11eb-84a5-beab6340b1bf.png">

should try with more samples per dimension

### Using fuse kernels (1D interpolation) 🤷‍♂️ 

<img width="1048" alt="Screen Shot 2021-04-19 at 15 17 35" src="https://user-images.githubusercontent.com/4757445/115260835-67189380-a133-11eb-9fd5-b46f7b70686b.png">

no benefit from fuse kernels. Real manipulation helps though!

### Using fuse kernels (2D interpolation)  👎 

<img width="1044" alt="Screen Shot 2021-04-19 at 15 19 32" src="https://user-images.githubusercontent.com/4757445/115261148-a810a800-a133-11eb-80a6-13a0accb28e4.png">

no benefit from either kernel or real manipulation...


### TODO
- Determine whether [custom kernels](https://docs.cupy.dev/en/stable/tutorial/kernel.html) are worth keeping for 2D. It makes internal machinery a bit harder to read and it's not clear whether there's really an improvement.